### PR TITLE
Implement app onboarding with organizations and teams

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.57.0",
     "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
+      react-hook-form:
+        specifier: ^7.57.0
+        version: 7.57.0(react@19.1.0)
       tailwind-merge:
         specifier: ^3.3.0
         version: 3.3.0
@@ -1640,6 +1643,12 @@ packages:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
       react: ^19.1.0
+
+  react-hook-form@7.57.0:
+    resolution: {integrity: sha512-RbEks3+cbvTP84l/VXGUZ+JMrKOS8ykQCRYdm5aYsxnDquL0vspsyNhGRO7pcH6hsZqWlPOjLye7rJqdtdAmlg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -3611,6 +3620,10 @@ snapshots:
     dependencies:
       react: 19.1.0
       scheduler: 0.26.0
+
+  react-hook-form@7.57.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   react-is@16.13.1: {}
 

--- a/src/app/app/[orgId]/[teamId]/dashboard/page.tsx
+++ b/src/app/app/[orgId]/[teamId]/dashboard/page.tsx
@@ -1,0 +1,21 @@
+import { createClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+import { LogoutButton } from '@/components/logout-button'
+
+export default async function DashboardPage({ params }: { params: { orgId: string; teamId: string } }) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth/login')
+  }
+
+  return (
+    <div className="flex h-svh w-full flex-col items-center justify-center gap-2">
+      <p>Dashboard for {params.orgId} / {params.teamId}</p>
+      <LogoutButton />
+    </div>
+  )
+}

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,0 +1,31 @@
+import { createClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+import OnboardingForm from '@/components/onboarding-form'
+
+export default async function AppPage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth/login')
+  }
+
+  const { data: orgs } = await supabase.rpc('supajump.get_organizations_for_current_user')
+  const { data: teams } = await supabase.rpc('supajump.get_teams_for_current_user')
+
+  if (orgs && orgs.length > 0 && teams && teams.length > 0) {
+    const orgId = orgs[0]
+    const teamId = teams[0]
+    redirect(`/app/${orgId}/${teamId}/dashboard`)
+  }
+
+  return (
+    <div className="flex min-h-svh w-full items-center justify-center p-6">
+      <div className="w-full max-w-sm">
+        <OnboardingForm />
+      </div>
+    </div>
+  )
+}

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -36,7 +36,7 @@ export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRe
       })
       if (error) throw error
       // Update this route to redirect to an authenticated route. The user already has an active session.
-      router.push('/protected')
+      router.push('/app')
     } catch (error: unknown) {
       setError(error instanceof Error ? error.message : 'An error occurred')
     } finally {

--- a/src/components/onboarding-form.tsx
+++ b/src/components/onboarding-form.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+import { createClient } from '@/lib/supabase/client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form'
+
+interface FormValues {
+  orgName: string
+  teamName: string
+}
+
+export default function OnboardingForm() {
+  const router = useRouter()
+  const form = useForm<FormValues>({
+    defaultValues: { orgName: '', teamName: '' },
+  })
+
+  async function onSubmit(values: FormValues) {
+    const supabase = createClient()
+
+    const { data: newOrgId, error: orgError } = await supabase.rpc('create_organization', {
+      name: values.orgName,
+    })
+    if (orgError || !newOrgId) {
+      console.error(orgError)
+      return
+    }
+
+    const { data: newTeamId, error: teamError } = await supabase.rpc(
+      'supajump.create_team_and_add_current_user_as_owner',
+      {
+        team_name: values.teamName,
+        org_id: newOrgId,
+      }
+    )
+    if (teamError || !newTeamId) {
+      console.error(teamError)
+      return
+    }
+
+    router.push(`/app/${newOrgId}/${newTeamId}/dashboard`)
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="orgName"
+          rules={{ required: 'Organization name is required' }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Organization Name</FormLabel>
+              <FormControl>
+                <Input placeholder="My Organization" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="teamName"
+          rules={{ required: 'Team name is required' }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Team Name</FormLabel>
+              <FormControl>
+                <Input placeholder="My Team" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" className="w-full">
+          Create Organization and Team
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/src/components/sign-up-form.tsx
+++ b/src/components/sign-up-form.tsx
@@ -41,7 +41,7 @@ export function SignUpForm({ className, ...props }: React.ComponentPropsWithoutR
         email,
         password,
         options: {
-          emailRedirectTo: `${window.location.origin}/protected`,
+          emailRedirectTo: `${window.location.origin}/app`,
         },
       })
       if (error) throw error

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import {
+  FormProvider,
+  useFormContext,
+  Controller,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from 'react-hook-form'
+
+import { cn } from '@/lib/utils'
+
+const Form = FormProvider
+
+interface FormFieldProps<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>>
+  extends Omit<ControllerProps<TFieldValues, TName>, 'render'> {
+  render: ControllerProps<TFieldValues, TName>['render']
+}
+
+function FormField<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>>({
+  ...props
+}: FormFieldProps<TFieldValues, TName>) {
+  return <Controller {...props} />
+}
+
+const FormItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('space-y-2', className)} {...props} />
+  )
+)
+FormItem.displayName = 'FormItem'
+
+const FormLabel = React.forwardRef<React.ElementRef<'label'>, React.ComponentPropsWithoutRef<'label'>>(
+  ({ className, ...props }, ref) => {
+    return <label ref={ref} className={cn(className)} {...props} />
+  }
+)
+FormLabel.displayName = 'FormLabel'
+
+const FormControl = React.forwardRef<React.ElementRef<typeof Slot>, React.ComponentPropsWithoutRef<typeof Slot>>(
+  ({ className, ...props }, ref) => {
+    return <Slot ref={ref} className={cn(className)} {...props} />
+  }
+)
+FormControl.displayName = 'FormControl'
+
+const FormMessage = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, children, ...props }, ref) => {
+    const { formState } = useFormContext()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const message = (props.id && (formState.errors as any)[props.id]?.message) as string | undefined
+    return (
+      <p ref={ref} className={cn('text-sm font-medium text-destructive', className)} {...props}>
+        {children ?? message}
+      </p>
+    )
+  }
+)
+FormMessage.displayName = 'FormMessage'
+
+export { Form, FormField, FormItem, FormLabel, FormControl, FormMessage }

--- a/src/components/update-password-form.tsx
+++ b/src/components/update-password-form.tsx
@@ -31,7 +31,7 @@ export function UpdatePasswordForm({ className, ...props }: React.ComponentProps
       const { error } = await supabase.auth.updateUser({ password })
       if (error) throw error
       // Update this route to redirect to an authenticated route. The user already has an active session.
-      router.push('/protected')
+      router.push('/app')
     } catch (error: unknown) {
       setError(error instanceof Error ? error.message : 'An error occurred')
     } finally {


### PR DESCRIPTION
## Summary
- add react-hook-form dependency
- redirect login/signup/update-password to `/app`
- create protected `/app` route that checks orgs/teams
- if user has both, redirect to `/app/[orgId]/[teamId]/dashboard`
- add onboarding flow to create first org and team with shadcn form components
- add basic dashboard page
- remove generated migration and keep schema updated

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684048e3b96c832fad3384d2d03bef04