### PR TITLE
Add role management and invitation pages

### DIFF
--- a/src/app/app/[org_id]/invite/page.tsx
+++ b/src/app/app/[org_id]/invite/page.tsx
@@ -1,0 +1,62 @@
+import { createClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+import InviteMemberForm from '@/components/invite-member-form'
+
+export default async function InvitePage({
+  params,
+}: {
+  params: Promise<{ org_id: string }>
+}) {
+  const { org_id } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth/login')
+  }
+
+  const { data: orgRoles } = await supabase
+    .from('roles')
+    .select('id, name, scope')
+    .eq('org_id', org_id)
+    .eq('scope', 'organization')
+
+  const { data: teams } = await supabase
+    .from('teams')
+    .select('id, name')
+    .eq('org_id', org_id)
+
+  const teamRolesMap: Record<string, { id: string; name: string }[]> = {}
+  if (teams && teams.length > 0) {
+    const teamIds = teams.map((t) => t.id)
+    const { data: teamRoles } = await supabase
+      .from('roles')
+      .select('id, name, team_id')
+      .eq('scope', 'team')
+      .in('team_id', teamIds)
+
+    if (teamRoles) {
+      for (const role of teamRoles) {
+        const list = teamRolesMap[role.team_id as string] || []
+        list.push({ id: role.id, name: role.name })
+        teamRolesMap[role.team_id as string] = list
+      }
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto p-6 max-w-xl">
+        <h1 className="mb-6 text-3xl font-bold">Invite Member</h1>
+        <InviteMemberForm
+          orgId={org_id}
+          orgRoles={orgRoles ?? []}
+          teams={teams ?? []}
+          teamRolesMap={teamRolesMap}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/app/app/[org_id]/roles/page.tsx
+++ b/src/app/app/[org_id]/roles/page.tsx
@@ -1,0 +1,33 @@
+import { createClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+import CreateRoleForm from '@/components/create-role-form'
+
+export default async function RolesPage({
+  params,
+}: {
+  params: Promise<{ org_id: string }>
+}) {
+  const { org_id } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth/login')
+  }
+
+  const { data: teams } = await supabase
+    .from('teams')
+    .select('id, name')
+    .eq('org_id', org_id)
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto p-6 max-w-xl">
+        <h1 className="mb-6 text-3xl font-bold">Create Role</h1>
+        <CreateRoleForm orgId={org_id} teams={teams ?? []} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/create-role-form.tsx
+++ b/src/components/create-role-form.tsx
@@ -1,0 +1,242 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm, useFieldArray } from 'react-hook-form'
+import { createClient } from '@/lib/supabase/client'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select'
+import { Label } from '@/components/ui/label'
+
+interface Permission {
+  resource: string
+  action: string
+}
+
+interface FormValues {
+  scope: 'organization' | 'team'
+  name: string
+  displayName: string
+  description: string
+  teamId?: string
+  permissions: Permission[]
+}
+
+interface CreateRoleFormProps {
+  orgId: string
+  teams: { id: string; name: string }[]
+}
+
+export default function CreateRoleForm({ orgId, teams }: CreateRoleFormProps) {
+  const supabase = createClient()
+  const form = useForm<FormValues>({
+    defaultValues: {
+      scope: 'organization',
+      name: '',
+      displayName: '',
+      description: '',
+      permissions: [{ resource: '', action: '' }],
+    },
+  })
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: 'permissions',
+  })
+  const scope = form.watch('scope')
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  async function onSubmit(values: FormValues) {
+    setIsLoading(true)
+    setError(null)
+    setSuccess(null)
+    const { data, error } = await supabase
+      .from('roles')
+      .insert({
+        scope: values.scope,
+        name: values.name,
+        display_name: values.displayName,
+        description: values.description,
+        org_id: orgId,
+        team_id: values.scope === 'team' ? values.teamId : null,
+      })
+      .select()
+      .single()
+
+    if (error || !data) {
+      setError(error?.message || 'Failed to create role')
+      setIsLoading(false)
+      return
+    }
+
+    for (const perm of values.permissions) {
+      const { error: permError } = await supabase.from('role_permissions').insert({
+        role_id: data.id,
+        org_id: orgId,
+        team_id: values.scope === 'team' ? values.teamId : null,
+        resource: perm.resource,
+        action: perm.action,
+      })
+      if (permError) {
+        setError(permError.message)
+        setIsLoading(false)
+        return
+      }
+    }
+
+    setSuccess('Role created successfully')
+    form.reset()
+    setIsLoading(false)
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="scope"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Scope</FormLabel>
+              <Select onValueChange={field.onChange} value={field.value}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select scope" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="organization">Organization</SelectItem>
+                  <SelectItem value="team">Team</SelectItem>
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        {scope === 'team' && (
+          <FormField
+            control={form.control}
+            name="teamId"
+            rules={{ required: 'Team is required' }}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Team</FormLabel>
+                <Select onValueChange={field.onChange} value={field.value}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select team" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {teams.map((team) => (
+                      <SelectItem key={team.id} value={team.id}>
+                        {team.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
+        <FormField
+          control={form.control}
+          name="name"
+          rules={{ required: 'Role name is required' }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Name</FormLabel>
+              <FormControl>
+                <Input placeholder="role_name" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="displayName"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Display Name</FormLabel>
+              <FormControl>
+                <Input placeholder="Display Name" {...field} />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Description</FormLabel>
+              <FormControl>
+                <Textarea rows={3} {...field} />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+        <div className="space-y-4">
+          <Label>Permissions</Label>
+          {fields.map((fieldItem, index) => (
+            <div key={fieldItem.id} className="grid grid-cols-2 gap-2">
+              <Input
+                placeholder="Resource"
+                {...form.register(`permissions.${index}.resource` as const, {
+                  required: 'Required',
+                })}
+              />
+              <Input
+                placeholder="Action"
+                {...form.register(`permissions.${index}.action` as const, {
+                  required: 'Required',
+                })}
+              />
+              <div className="col-span-2 text-right">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => remove(index)}
+                >
+                  Remove
+                </Button>
+              </div>
+            </div>
+          ))}
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => append({ resource: '', action: '' })}
+          >
+            Add Permission
+          </Button>
+        </div>
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        {success && <p className="text-sm text-green-500">{success}</p>}
+        <Button type="submit" className="w-full" disabled={isLoading}>
+          {isLoading ? 'Creating...' : 'Create Role'}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/src/components/invite-member-form.tsx
+++ b/src/components/invite-member-form.tsx
@@ -1,0 +1,183 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm, useFieldArray } from 'react-hook-form'
+import { createClient } from '@/lib/supabase/client'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select'
+import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
+
+interface TeamRole {
+  teamId: string
+  roleIds: string[]
+}
+
+interface FormValues {
+  email: string
+  orgRoleIds: string[]
+  teamRoles: TeamRole[]
+}
+
+interface InviteMemberFormProps {
+  orgId: string
+  orgRoles: { id: string; name: string }[]
+  teams: { id: string; name: string }[]
+  teamRolesMap: Record<string, { id: string; name: string }[]>
+}
+
+export default function InviteMemberForm({
+  orgId,
+  orgRoles,
+  teams,
+  teamRolesMap,
+}: InviteMemberFormProps) {
+  const supabase = createClient()
+  const form = useForm<FormValues>({
+    defaultValues: { email: '', orgRoleIds: [], teamRoles: [] },
+  })
+  const { fields: teamRoleFields, append, remove } = useFieldArray({
+    control: form.control,
+    name: 'teamRoles',
+  })
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const addTeamRole = () => append({ teamId: '', roleIds: [] })
+
+  async function onSubmit(values: FormValues) {
+    setIsLoading(true)
+    setError(null)
+    setSuccess(null)
+
+    const teamAssignments = values.teamRoles
+      .filter((tr) => tr.teamId && tr.roleIds.length > 0)
+      .flatMap((tr) => tr.roleIds.map((r) => ({ project_id: tr.teamId, role: r })))
+
+    const { error } = await supabase.rpc('create_org_invite', {
+      input_org_id: orgId,
+      org_member_role_id: values.orgRoleIds[0],
+      invitee_email: values.email,
+      invitation_type: 'one-time',
+      project_member_roles: teamAssignments.length > 0 ? teamAssignments : null,
+    })
+
+    if (error) {
+      setError(error.message)
+      setIsLoading(false)
+      return
+    }
+
+    setSuccess('Invitation sent')
+    form.reset()
+    setIsLoading(false)
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="email"
+          rules={{ required: 'Email is required' }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="user@example.com" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="space-y-2">
+          <Label>Organization Roles</Label>
+          {orgRoles.map((role) => (
+            <div key={role.id} className="flex items-center gap-2">
+              <Checkbox
+                id={`org-role-${role.id}`}
+                {...form.register('orgRoleIds')}
+                value={role.id}
+              />
+              <label htmlFor={`org-role-${role.id}`}>{role.name}</label>
+            </div>
+          ))}
+        </div>
+        <div className="space-y-4">
+          <div className="flex justify-between items-center">
+            <Label>Team Memberships</Label>
+            <Button type="button" size="sm" variant="secondary" onClick={addTeamRole}>
+              Add Team
+            </Button>
+          </div>
+          {teamRoleFields.map((fieldItem, index) => (
+            <div key={fieldItem.id} className="border p-4 rounded-md space-y-4">
+              <FormField
+                control={form.control}
+                name={`teamRoles.${index}.teamId` as const}
+                rules={{ required: 'Team is required' }}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Team</FormLabel>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select team" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {teams.map((t) => (
+                          <SelectItem key={t.id} value={t.id}>
+                            {t.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="space-y-2">
+                <Label>Roles</Label>
+                {teamRolesMap[form.watch(`teamRoles.${index}.teamId`) ?? '']?.map((r) => (
+                  <div key={r.id} className="flex items-center gap-2">
+                    <Checkbox
+                      id={`team-${index}-role-${r.id}`}
+                      {...form.register(`teamRoles.${index}.roleIds` as const)}
+                      value={r.id}
+                    />
+                    <label htmlFor={`team-${index}-role-${r.id}`}>{r.name}</label>
+                  </div>
+                ))}
+              </div>
+              <Button type="button" variant="outline" size="sm" onClick={() => remove(index)}>
+                Remove
+              </Button>
+            </div>
+          ))}
+        </div>
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        {success && <p className="text-sm text-green-500">{success}</p>}
+        <Button type="submit" className="w-full" disabled={isLoading}>
+          {isLoading ? 'Sending...' : 'Send Invite'}
+        </Button>
+      </form>
+    </Form>
+  )
+}


### PR DESCRIPTION
## Summary
- add create role form and invite member form
- add new routes for creating roles and inviting members
- fetch roles and teams on the server and pass as props

## Testing
- `npx next lint`


------
https://chatgpt.com/codex/tasks/task_e_68439bd1f478832f868bab0f0d83decb