### PR TITLE
Add roles data table

### DIFF
--- a/src/app/app/[org_id]/roles/columns.tsx
+++ b/src/app/app/[org_id]/roles/columns.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { ColumnDef } from '@tanstack/react-table'
+import { type Database } from '@/lib/database.types'
+
+export type Role = Database['public']['Tables']['roles']['Row']
+
+export const columns: ColumnDef<Role>[] = [
+  {
+    accessorKey: 'name',
+    header: 'Name',
+  },
+  {
+    accessorKey: 'scope',
+    header: 'Scope',
+  },
+  {
+    accessorKey: 'description',
+    header: 'Description',
+  },
+]

--- a/src/app/app/[org_id]/roles/page.tsx
+++ b/src/app/app/[org_id]/roles/page.tsx
@@ -1,6 +1,8 @@
+import { DataTable } from '@/components/data-table/data-table'
+import CreateRoleForm from '@/components/create-role-form'
 import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
-import CreateRoleForm from '@/components/create-role-form'
+import { columns, type Role } from './columns'
 
 export default async function RolesPage({
   params,
@@ -22,11 +24,20 @@ export default async function RolesPage({
     .select('id, name')
     .eq('org_id', org_id)
 
+  const { data: roles } = await supabase
+    .from('roles')
+    .select('*')
+    .eq('org_id', org_id)
+
   return (
     <div className="min-h-screen bg-background">
       <div className="container mx-auto p-6 max-w-xl">
         <h1 className="mb-6 text-3xl font-bold">Create Role</h1>
         <CreateRoleForm orgId={org_id} teams={teams ?? []} />
+      </div>
+      <div className="container mx-auto p-6">
+        <h2 className="mb-4 text-2xl font-bold">Roles</h2>
+        <DataTable columns={columns} data={(roles ?? []) as Role[]} />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- display roles in a new data table
- create column definitions for roles

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843c25d9f40832fafcbb39043096a17