### PR TITLE
Add profile management page

### DIFF
--- a/src/app/api/delete-account/route.ts
+++ b/src/app/api/delete-account/route.ts
@@ -1,0 +1,40 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+export async function POST() {
+  const cookieStore = cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            cookieStore.set(name, value, options)
+          )
+        },
+      },
+    }
+  )
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const admin = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  await admin.auth.admin.deleteUser(user.id)
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,35 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { UpdateProfileForm } from '@/components/update-profile-form'
+import { ChangePasswordForm } from '@/components/change-password-form'
+import { DeleteAccountButton } from '@/components/delete-account-button'
+
+export default async function ProfilePage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth/login')
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('id', user.id)
+    .single()
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto p-6 max-w-xl space-y-10">
+        <h1 className="text-3xl font-bold">Profile</h1>
+        {profile && <UpdateProfileForm profile={profile} />}
+        <ChangePasswordForm />
+        <div className="pt-6 border-t">
+          <DeleteAccountButton />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/change-password-form.tsx
+++ b/src/components/change-password-form.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { createClient } from '@/lib/supabase/client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form'
+
+interface FormValues {
+  password: string
+  confirm: string
+}
+
+export function ChangePasswordForm() {
+  const form = useForm<FormValues>({ defaultValues: { password: '', confirm: '' } })
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  async function onSubmit(values: FormValues) {
+    if (values.password !== values.confirm) {
+      setError('Passwords do not match')
+      return
+    }
+    setIsLoading(true)
+    setError(null)
+    setSuccess(null)
+    const supabase = createClient()
+    const { error } = await supabase.auth.updateUser({ password: values.password })
+    if (error) {
+      setError(error.message)
+    } else {
+      setSuccess('Password updated')
+      form.reset()
+    }
+    setIsLoading(false)
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="password"
+          rules={{ required: 'Password is required' }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>New Password</FormLabel>
+              <FormControl>
+                <Input type="password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="confirm"
+          rules={{ required: 'Please confirm password' }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Confirm Password</FormLabel>
+              <FormControl>
+                <Input type="password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        {success && <p className="text-sm text-green-500">{success}</p>}
+        <Button type="submit" className="w-full" disabled={isLoading}>
+          {isLoading ? 'Saving...' : 'Change Password'}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/src/components/delete-account-button.tsx
+++ b/src/components/delete-account-button.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog'
+
+export function DeleteAccountButton() {
+  const [value, setValue] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const router = useRouter()
+
+  const handleDelete = async () => {
+    setIsLoading(true)
+    await fetch('/api/delete-account', { method: 'POST' })
+    router.push('/auth/login')
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive">Delete Account</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete Account</AlertDialogTitle>
+          <AlertDialogDescription>
+            This action is irreversible. Type DELETE to confirm.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <Input value={value} onChange={(e) => setValue(e.target.value)} />
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction asChild>
+            <Button
+              variant="destructive"
+              disabled={value !== 'DELETE' || isLoading}
+              onClick={handleDelete}
+            >
+              {isLoading ? 'Deleting...' : 'Delete'}
+            </Button>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -8,6 +8,7 @@ import {
   LogOut,
   Sparkles,
 } from "lucide-react"
+import { useRouter } from "next/navigation"
 
 import {
   Avatar,
@@ -40,6 +41,7 @@ export function NavUser({
   }
 }) {
   const { isMobile } = useSidebar()
+  const router = useRouter()
 
   return (
     <SidebarMenu>
@@ -88,7 +90,10 @@ export function NavUser({
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
-              <DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => router.push('/profile')}
+                className="cursor-pointer"
+              >
                 <BadgeCheck />
                 Account
               </DropdownMenuItem>

--- a/src/components/update-profile-form.tsx
+++ b/src/components/update-profile-form.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { createClient } from '@/lib/supabase/client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form'
+import type { Database } from '@/lib/database.types'
+
+interface UpdateProfileFormProps {
+  profile: Database['public']['Tables']['profiles']['Row']
+}
+
+interface FormValues {
+  user_name: string
+  first_name: string
+  last_name: string
+}
+
+export function UpdateProfileForm({ profile }: UpdateProfileFormProps) {
+  const form = useForm<FormValues>({
+    defaultValues: {
+      user_name: profile.user_name ?? '',
+      first_name: profile.first_name ?? '',
+      last_name: profile.last_name ?? '',
+    },
+  })
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  async function onSubmit(values: FormValues) {
+    setIsLoading(true)
+    setError(null)
+    setSuccess(null)
+    const supabase = createClient()
+    const { error } = await supabase
+      .from('profiles')
+      .update({
+        user_name: values.user_name,
+        first_name: values.first_name,
+        last_name: values.last_name,
+      })
+      .eq('id', profile.id)
+    if (error) {
+      setError(error.message)
+    } else {
+      setSuccess('Profile updated')
+    }
+    setIsLoading(false)
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="user_name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Username</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="first_name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>First Name</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="last_name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Last Name</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        {success && <p className="text-sm text-green-500">{success}</p>}
+        <Button type="submit" className="w-full" disabled={isLoading}>
+          {isLoading ? 'Saving...' : 'Save Changes'}
+        </Button>
+      </form>
+    </Form>
+  )
+}


### PR DESCRIPTION
## Summary
- add a profile page
- provide UpdateProfileForm, ChangePasswordForm and DeleteAccountButton
- expose a delete-account API route using service role
- allow navigating to profile from the user dropdown

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6843c49b70bc832f855d17b9e5eb300a