### PR TITLE
Add organization selection to /app

### DIFF
--- a/src/app/app/[org_id]/page.tsx
+++ b/src/app/app/[org_id]/page.tsx
@@ -1,0 +1,59 @@
+import { createClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+import { Card, CardHeader, CardTitle } from '@/components/ui/card'
+import Link from 'next/link'
+
+export default async function OrgPage({
+  params,
+}: {
+  params: Promise<{ org_id: string }>
+}) {
+  const { org_id } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth/login')
+  }
+
+  const { data: teamIds } = await supabase.rpc('supajump.get_teams_for_current_user')
+
+  if (!teamIds || teamIds.length === 0) {
+    return (
+      <div className='flex min-h-svh w-full items-center justify-center p-6'>
+        <p className='text-sm text-muted-foreground'>No teams found.</p>
+      </div>
+    )
+  }
+
+  const { data: teams } = await supabase
+    .from('teams')
+    .select('id, name, org_id')
+    .in('id', teamIds)
+    .eq('org_id', org_id)
+
+  if (teams && teams.length === 1) {
+    redirect(`/app/${org_id}/${teams[0].id}/dashboard`)
+  }
+
+  return (
+    <div className='min-h-svh bg-background'>
+      <div className='container mx-auto p-6'>
+        <h1 className='mb-6 text-3xl font-bold'>Select Team</h1>
+        <div className='grid gap-6 sm:grid-cols-2 md:grid-cols-3'>
+          {teams?.map((team) => (
+            <Card key={team.id} className='hover:bg-muted'>
+              <Link href={`/app/${org_id}/${team.id}/dashboard`} className='block p-4'>
+                <CardHeader className='p-0'>
+                  <CardTitle>{team.name}</CardTitle>
+                </CardHeader>
+              </Link>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,6 +1,8 @@
 import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import OnboardingForm from '@/components/onboarding-form'
+import { Card, CardHeader, CardTitle } from '@/components/ui/card'
+import Link from 'next/link'
 
 export default async function AppPage() {
   const supabase = await createClient()
@@ -12,19 +14,42 @@ export default async function AppPage() {
     redirect('/auth/login')
   }
 
-  const { data: orgs } = await supabase.rpc('supajump.get_organizations_for_current_user')
-  const { data: teams } = await supabase.rpc('supajump.get_teams_for_current_user')
+  const { data: orgIds } = await supabase.rpc('supajump.get_organizations_for_current_user')
 
-  if (orgs && orgs.length > 0 && teams && teams.length > 0) {
-    const orgId = orgs[0]
-    const teamId = teams[0]
-    redirect(`/app/${orgId}/${teamId}/dashboard`)
+  if (!orgIds || orgIds.length === 0) {
+    return (
+      <div className='flex min-h-svh w-full items-center justify-center p-6'>
+        <div className='w-full max-w-sm'>
+          <OnboardingForm />
+        </div>
+      </div>
+    )
   }
 
+  if (orgIds.length === 1) {
+    redirect(`/app/${orgIds[0]}`)
+  }
+
+  const { data: organizations } = await supabase
+    .from('organizations')
+    .select('id, name')
+    .in('id', orgIds)
+
   return (
-    <div className="flex min-h-svh w-full items-center justify-center p-6">
-      <div className="w-full max-w-sm">
-        <OnboardingForm />
+    <div className='min-h-svh bg-background'>
+      <div className='container mx-auto p-6'>
+        <h1 className='mb-6 text-3xl font-bold'>Select Organization</h1>
+        <div className='grid gap-6 sm:grid-cols-2 md:grid-cols-3'>
+          {organizations?.map((org) => (
+            <Card key={org.id} className='hover:bg-muted'>
+              <Link href={`/app/${org.id}`} className='block p-4'>
+                <CardHeader className='p-0'>
+                  <CardTitle>{org.name}</CardTitle>
+                </CardHeader>
+              </Link>
+            </Card>
+          ))}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- display organizations on `/app` if multiple exist
- redirect to organization's page if only one is available
- add page to handle `/app/[org_id]` with team selection

## Testing
- `pnpm lint`
- `pnpm test` *(fails: no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_6843c553b0a0832f908304cb51db8801