### PR TITLE
Add dynamic breadcrumbs

### DIFF
--- a/src/app/app/[org_id]/layout.tsx
+++ b/src/app/app/[org_id]/layout.tsx
@@ -1,12 +1,5 @@
 import { AppSidebar } from '@/components/app-sidebar';
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from '@/components/ui/breadcrumb';
+import Breadcrumbs from '@/components/breadcrumbs';
 import { Separator } from '@/components/ui/separator';
 import {
   SidebarInset,
@@ -33,19 +26,7 @@ export default async function Page({
               orientation='vertical'
               className='mr-2 data-[orientation=vertical]:h-4'
             />
-            <Breadcrumb>
-              <BreadcrumbList>
-                <BreadcrumbItem className='hidden md:block'>
-                  <BreadcrumbLink href='#'>
-                    Building Your Application
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator className='hidden md:block' />
-                <BreadcrumbItem>
-                  <BreadcrumbPage>Data Fetching</BreadcrumbPage>
-                </BreadcrumbItem>
-              </BreadcrumbList>
-            </Breadcrumb>
+            <Breadcrumbs />
           </div>
         </header>
         <div className='flex flex-1 flex-col gap-4 p-4 pt-0'>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,12 +1,5 @@
 import { AppSidebar } from "@/components/app-sidebar"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb"
+import Breadcrumbs from "@/components/breadcrumbs"
 import { Separator } from "@/components/ui/separator"
 import {
   SidebarInset,
@@ -26,19 +19,7 @@ export default function Page() {
               orientation="vertical"
               className="mr-2 data-[orientation=vertical]:h-4"
             />
-            <Breadcrumb>
-              <BreadcrumbList>
-                <BreadcrumbItem className="hidden md:block">
-                  <BreadcrumbLink href="#">
-                    Building Your Application
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator className="hidden md:block" />
-                <BreadcrumbItem>
-                  <BreadcrumbPage>Data Fetching</BreadcrumbPage>
-                </BreadcrumbItem>
-              </BreadcrumbList>
-            </Breadcrumb>
+            <Breadcrumbs />
           </div>
         </header>
         <div className="flex flex-1 flex-col gap-4 p-4 pt-0">

--- a/src/components/breadcrumbs.tsx
+++ b/src/components/breadcrumbs.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import React from 'react'
+import Link from 'next/link'
+import { usePathname, useSearchParams } from 'next/navigation'
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb'
+
+function getSearchPathnames(searchParams: ReturnType<typeof useSearchParams>) {
+  const params = searchParams.getAll('pathname')
+  if (params.length > 0) return params
+  const param = searchParams.get('pathnames')
+  if (param) return param.split('/').filter(Boolean)
+  return []
+}
+
+export default function Breadcrumbs() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const searchSegments = getSearchPathnames(searchParams)
+  const segments =
+    searchSegments.length > 0
+      ? searchSegments
+      : pathname
+          .split('?')[0]
+          .split('/')
+          .filter(Boolean)
+
+  const breadcrumbs = segments.map((segment, index) => {
+    const href = '/' + segments.slice(0, index + 1).join('/')
+    const name = decodeURIComponent(segment.replace(/-/g, ' '))
+    return { href, name }
+  })
+
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        {breadcrumbs.map((bc, idx) => (
+          <React.Fragment key={bc.href}>
+            <BreadcrumbItem>
+              {idx === breadcrumbs.length - 1 ? (
+                <BreadcrumbPage>{bc.name}</BreadcrumbPage>
+              ) : (
+                <BreadcrumbLink asChild>
+                  <Link href={bc.href}>{bc.name}</Link>
+                </BreadcrumbLink>
+              )}
+            </BreadcrumbItem>
+            {idx !== breadcrumbs.length - 1 && <BreadcrumbSeparator />}
+          </React.Fragment>
+        ))}
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}
+


### PR DESCRIPTION
## Summary
- create a `Breadcrumbs` component to build breadcrumb links from the current URL
- use the new component in the dashboard page
- use the new component in the org layout

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6843c65e81f4832f940d3ed0815df81e