### PR TITLE
Add organization and team settings

### DIFF
--- a/src/app/app/[org_id]/[team_id]/settings/page.tsx
+++ b/src/app/app/[org_id]/[team_id]/settings/page.tsx
@@ -1,0 +1,38 @@
+import { createClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+import UpdateOrganizationForm from '@/components/update-organization-form'
+import { DeleteOrganizationButton } from '@/components/delete-organization-button'
+
+export default async function OrganizationSettingsPage({
+  params,
+}: {
+  params: Promise<{ org_id: string; team_id: string }>
+}) {
+  const { org_id } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth/login')
+  }
+
+  const { data: organization } = await supabase
+    .from('organizations')
+    .select('*')
+    .eq('id', org_id)
+    .single()
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto p-6 max-w-xl space-y-10">
+        <h1 className="text-3xl font-bold">Organization Settings</h1>
+        {organization && <UpdateOrganizationForm organization={organization} />}
+        <div className="pt-6 border-t">
+          <DeleteOrganizationButton orgId={org_id} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/app/[org_id]/[team_id]/settings/team/page.tsx
+++ b/src/app/app/[org_id]/[team_id]/settings/team/page.tsx
@@ -1,0 +1,38 @@
+import { createClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+import UpdateTeamForm from '@/components/update-team-form'
+import { DeleteTeamButton } from '@/components/delete-team-button'
+
+export default async function TeamSettingsPage({
+  params,
+}: {
+  params: Promise<{ org_id: string; team_id: string }>
+}) {
+  const { org_id, team_id } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth/login')
+  }
+
+  const { data: team } = await supabase
+    .from('teams')
+    .select('*')
+    .eq('id', team_id)
+    .single()
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto p-6 max-w-xl space-y-10">
+        <h1 className="text-3xl font-bold">Team Settings</h1>
+        {team && <UpdateTeamForm team={team} />}
+        <div className="pt-6 border-t">
+          <DeleteTeamButton orgId={org_id} teamId={team_id} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/app/[org_id]/settings/page.tsx
+++ b/src/app/app/[org_id]/settings/page.tsx
@@ -1,0 +1,38 @@
+import { createClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+import UpdateOrganizationForm from '@/components/update-organization-form'
+import { DeleteOrganizationButton } from '@/components/delete-organization-button'
+
+export default async function OrganizationSettingsPage({
+  params,
+}: {
+  params: Promise<{ org_id: string }>
+}) {
+  const { org_id } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth/login')
+  }
+
+  const { data: organization } = await supabase
+    .from('organizations')
+    .select('*')
+    .eq('id', org_id)
+    .single()
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto p-6 max-w-xl space-y-10">
+        <h1 className="text-3xl font-bold">Organization Settings</h1>
+        {organization && <UpdateOrganizationForm organization={organization} />}
+        <div className="pt-6 border-t">
+          <DeleteOrganizationButton orgId={org_id} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/delete-organization-button.tsx
+++ b/src/components/delete-organization-button.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog'
+import { createClient } from '@/lib/supabase/client'
+
+export function DeleteOrganizationButton({ orgId }: { orgId: string }) {
+  const [value, setValue] = useState('')
+  const [step, setStep] = useState(1)
+  const [isLoading, setIsLoading] = useState(false)
+  const router = useRouter()
+
+  const handleDelete = async () => {
+    setIsLoading(true)
+    const supabase = createClient()
+    await supabase.from('organizations').delete().eq('id', orgId)
+    router.push('/app')
+  }
+
+  return (
+    <AlertDialog
+      onOpenChange={(open) => {
+        if (!open) {
+          setStep(1)
+          setValue('')
+        }
+      }}
+    >
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive">Delete Organization</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        {step === 1 ? (
+          <>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete Organization</AlertDialogTitle>
+              <AlertDialogDescription>
+                This action is irreversible. Type DELETE to continue.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <Input value={value} onChange={(e) => setValue(e.target.value)} />
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction asChild>
+                <Button
+                  variant="destructive"
+                  disabled={value !== 'DELETE'}
+                  onClick={() => setStep(2)}
+                >
+                  Continue
+                </Button>
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </>
+        ) : (
+          <>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will permanently delete the organization and all related data.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction asChild>
+                <Button
+                  variant="destructive"
+                  disabled={isLoading}
+                  onClick={handleDelete}
+                >
+                  {isLoading ? 'Deleting...' : 'Delete'}
+                </Button>
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </>
+        )}
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/components/delete-team-button.tsx
+++ b/src/components/delete-team-button.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog'
+import { createClient } from '@/lib/supabase/client'
+
+export function DeleteTeamButton({ orgId, teamId }: { orgId: string; teamId: string }) {
+  const [value, setValue] = useState('')
+  const [step, setStep] = useState(1)
+  const [isLoading, setIsLoading] = useState(false)
+  const router = useRouter()
+
+  const handleDelete = async () => {
+    setIsLoading(true)
+    const supabase = createClient()
+    await supabase.from('teams').delete().eq('id', teamId)
+    router.push(`/app/${orgId}`)
+  }
+
+  return (
+    <AlertDialog
+      onOpenChange={(open) => {
+        if (!open) {
+          setStep(1)
+          setValue('')
+        }
+      }}
+    >
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive">Delete Team</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        {step === 1 ? (
+          <>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete Team</AlertDialogTitle>
+              <AlertDialogDescription>
+                This action is irreversible. Type DELETE to continue.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <Input value={value} onChange={(e) => setValue(e.target.value)} />
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction asChild>
+                <Button
+                  variant="destructive"
+                  disabled={value !== 'DELETE'}
+                  onClick={() => setStep(2)}
+                >
+                  Continue
+                </Button>
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </>
+        ) : (
+          <>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will permanently delete the team and all related data.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction asChild>
+                <Button
+                  variant="destructive"
+                  disabled={isLoading}
+                  onClick={handleDelete}
+                >
+                  {isLoading ? 'Deleting...' : 'Delete'}
+                </Button>
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </>
+        )}
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/components/update-organization-form.tsx
+++ b/src/components/update-organization-form.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { createClient } from '@/lib/supabase/client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form'
+import type { Database } from '@/lib/database.types'
+
+interface UpdateOrganizationFormProps {
+  organization: Database['public']['Tables']['organizations']['Row']
+}
+
+interface FormValues {
+  name: string
+}
+
+export default function UpdateOrganizationForm({ organization }: UpdateOrganizationFormProps) {
+  const form = useForm<FormValues>({
+    defaultValues: {
+      name: organization.name ?? '',
+    },
+  })
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  async function onSubmit(values: FormValues) {
+    setIsLoading(true)
+    setError(null)
+    setSuccess(null)
+    const supabase = createClient()
+    const { error } = await supabase
+      .from('organizations')
+      .update({ name: values.name })
+      .eq('id', organization.id)
+
+    if (error) {
+      setError(error.message)
+    } else {
+      setSuccess('Organization updated')
+    }
+    setIsLoading(false)
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Name</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        {success && <p className="text-sm text-green-500">{success}</p>}
+        <Button type="submit" className="w-full" disabled={isLoading}>
+          {isLoading ? 'Saving...' : 'Save Changes'}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/src/components/update-team-form.tsx
+++ b/src/components/update-team-form.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { createClient } from '@/lib/supabase/client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form'
+import type { Database } from '@/lib/database.types'
+
+interface UpdateTeamFormProps {
+  team: Database['public']['Tables']['teams']['Row']
+}
+
+interface FormValues {
+  name: string
+}
+
+export default function UpdateTeamForm({ team }: UpdateTeamFormProps) {
+  const form = useForm<FormValues>({
+    defaultValues: {
+      name: team.name ?? '',
+    },
+  })
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  async function onSubmit(values: FormValues) {
+    setIsLoading(true)
+    setError(null)
+    setSuccess(null)
+    const supabase = createClient()
+    const { error } = await supabase
+      .from('teams')
+      .update({ name: values.name })
+      .eq('id', team.id)
+
+    if (error) {
+      setError(error.message)
+    } else {
+      setSuccess('Team updated')
+    }
+    setIsLoading(false)
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Name</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        {success && <p className="text-sm text-green-500">{success}</p>}
+        <Button type="submit" className="w-full" disabled={isLoading}>
+          {isLoading ? 'Saving...' : 'Save Changes'}
+        </Button>
+      </form>
+    </Form>
+  )
+}


### PR DESCRIPTION
## Summary
- add organization settings page
- add team settings page and general settings path
- support editing organizations and teams
- add deletion buttons with double-confirm dialogs

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6843c735c9f8832f97d16e8e4eac2079