### PR TITLE
Add React Query setup

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import QueryProvider from "@/components/providers/query-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <QueryProvider>{children}</QueryProvider>
       </body>
     </html>
   );

--- a/src/components/providers/get-query-client.ts
+++ b/src/components/providers/get-query-client.ts
@@ -1,0 +1,38 @@
+import {
+  isServer,
+  QueryClient,
+  defaultShouldDehydrateQuery,
+} from '@tanstack/react-query'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+      },
+      dehydrate: {
+        // include pending queries in dehydration
+        shouldDehydrateQuery: (query) =>
+          defaultShouldDehydrateQuery(query) ||
+          query.state.status === 'pending',
+        shouldRedactErrors: () => {
+          // Next.js will handle server errors
+          return false
+        },
+      },
+    },
+  })
+}
+
+let browserQueryClient: QueryClient | undefined = undefined
+
+export function getQueryClient() {
+  if (isServer) {
+    // Server: always make a new query client
+    return makeQueryClient()
+  } else {
+    // Browser: reuse query client across renders
+    if (!browserQueryClient) browserQueryClient = makeQueryClient()
+    return browserQueryClient
+  }
+}

--- a/src/components/providers/query-provider.tsx
+++ b/src/components/providers/query-provider.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { QueryClientProvider } from '@tanstack/react-query'
+import { ReactNode } from 'react'
+import { getQueryClient } from './get-query-client'
+
+export default function QueryProvider({
+  children,
+}: {
+  children: ReactNode
+}) {
+  const queryClient = getQueryClient()
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}


### PR DESCRIPTION
## Summary
- create query client provider and getQueryClient util
- wrap layout with QueryProvider to enable React Query

## Testing
- `pnpm lint` *(fails: Failed to load config "@tanstack/eslint-plugin-query" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68449b4d3e70832fbee4011c979d3474