### PR TITLE
Refactor queries with React Query

### DIFF
--- a/src/app/api/revalidate-tag/route.ts
+++ b/src/app/api/revalidate-tag/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { revalidateTag } from 'next/cache'
+
+export async function POST(request: NextRequest) {
+  const { tag } = await request.json()
+  if (!tag) {
+    return NextResponse.json({ error: 'Tag is required' }, { status: 400 })
+  }
+  try {
+    await revalidateTag(tag)
+    return NextResponse.json({ revalidated: true })
+  } catch (err) {
+    return NextResponse.json({ error: 'Failed to revalidate' }, { status: 500 })
+  }
+}

--- a/src/app/app/[org_id]/[team_id]/posts/page.tsx
+++ b/src/app/app/[org_id]/[team_id]/posts/page.tsx
@@ -1,34 +1,34 @@
-import { DataTable } from '@/components/data-table/data-table';
-import { columns, type Post } from './columns';
-import { createClient } from '@/lib/supabase/server';
-import { redirect } from 'next/navigation';
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
+import { getQueryClient } from '@/components/providers/get-query-client'
+import { fetchPosts } from '@/queries/posts'
+import PostsTable from '@/components/posts-table'
 
 export default async function Page({
   params,
 }: {
-  params: Promise<{ org_id: string; team_id: string }>;
+  params: Promise<{ org_id: string; team_id: string }>
 }) {
-  const { org_id, team_id } = await params;
-  const supabase = await createClient();
-  const { data: user } = await supabase.auth.getUser();
+  const { org_id, team_id } = await params
+  const supabase = await createClient()
+  const { data: user } = await supabase.auth.getUser()
   if (!user) {
-    redirect('/auth/login');
+    redirect('/auth/login')
   }
-  const { data: posts, error } = await supabase
-    .from('posts')
-    .select('*')
-    .eq('org_id', org_id)
-    .eq('team_id', team_id)
-    .order('created_at', { ascending: false });
 
-  if (error) {
-    console.error(error);
-  }
+  const queryClient = getQueryClient()
+  await queryClient.prefetchQuery({
+    queryKey: ['posts', org_id, team_id],
+    queryFn: () => fetchPosts(org_id, team_id),
+  })
 
   return (
-    <div className='flex flex-col gap-4'>
-      <h1 className='text-2xl font-bold'>Posts</h1>
-      <DataTable columns={columns} data={(posts ?? []) as Post[]} />
-    </div>
-  );
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <div className='flex flex-col gap-4'>
+        <h1 className='text-2xl font-bold'>Posts</h1>
+        <PostsTable orgId={org_id} teamId={team_id} />
+      </div>
+    </HydrationBoundary>
+  )
 }

--- a/src/app/app/[org_id]/[team_id]/settings/page.tsx
+++ b/src/app/app/[org_id]/[team_id]/settings/page.tsx
@@ -1,7 +1,10 @@
-import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
 import UpdateOrganizationForm from '@/components/update-organization-form'
 import { DeleteOrganizationButton } from '@/components/delete-organization-button'
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
+import { getQueryClient } from '@/components/providers/get-query-client'
+import { fetchOrganization } from '@/queries/organizations'
 
 export default async function OrganizationSettingsPage({
   params,
@@ -18,21 +21,23 @@ export default async function OrganizationSettingsPage({
     redirect('/auth/login')
   }
 
-  const { data: organization } = await supabase
-    .from('organizations')
-    .select('*')
-    .eq('id', org_id)
-    .single()
+  const queryClient = getQueryClient()
+  await queryClient.prefetchQuery({
+    queryKey: ['organization', org_id],
+    queryFn: () => fetchOrganization(org_id),
+  })
 
   return (
-    <div className="min-h-screen bg-background">
-      <div className="container mx-auto p-6 max-w-xl space-y-10">
-        <h1 className="text-3xl font-bold">Organization Settings</h1>
-        {organization && <UpdateOrganizationForm organization={organization} />}
-        <div className="pt-6 border-t">
-          <DeleteOrganizationButton orgId={org_id} />
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <div className='min-h-screen bg-background'>
+        <div className='container mx-auto p-6 max-w-xl space-y-10'>
+          <h1 className='text-3xl font-bold'>Organization Settings</h1>
+          <UpdateOrganizationForm orgId={org_id} />
+          <div className='pt-6 border-t'>
+            <DeleteOrganizationButton orgId={org_id} />
+          </div>
         </div>
       </div>
-    </div>
+    </HydrationBoundary>
   )
 }

--- a/src/app/app/[org_id]/settings/page.tsx
+++ b/src/app/app/[org_id]/settings/page.tsx
@@ -1,7 +1,10 @@
-import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
 import UpdateOrganizationForm from '@/components/update-organization-form'
 import { DeleteOrganizationButton } from '@/components/delete-organization-button'
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
+import { getQueryClient } from '@/components/providers/get-query-client'
+import { fetchOrganization } from '@/queries/organizations'
 
 export default async function OrganizationSettingsPage({
   params,
@@ -18,21 +21,23 @@ export default async function OrganizationSettingsPage({
     redirect('/auth/login')
   }
 
-  const { data: organization } = await supabase
-    .from('organizations')
-    .select('*')
-    .eq('id', org_id)
-    .single()
+  const queryClient = getQueryClient()
+  await queryClient.prefetchQuery({
+    queryKey: ['organization', org_id],
+    queryFn: () => fetchOrganization(org_id),
+  })
 
   return (
-    <div className="min-h-screen bg-background">
-      <div className="container mx-auto p-6 max-w-xl space-y-10">
-        <h1 className="text-3xl font-bold">Organization Settings</h1>
-        {organization && <UpdateOrganizationForm organization={organization} />}
-        <div className="pt-6 border-t">
-          <DeleteOrganizationButton orgId={org_id} />
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <div className='min-h-screen bg-background'>
+        <div className='container mx-auto p-6 max-w-xl space-y-10'>
+          <h1 className='text-3xl font-bold'>Organization Settings</h1>
+          <UpdateOrganizationForm orgId={org_id} />
+          <div className='pt-6 border-t'>
+            <DeleteOrganizationButton orgId={org_id} />
+          </div>
         </div>
       </div>
-    </div>
+    </HydrationBoundary>
   )
 }

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,23 +1,28 @@
-import { createClient } from '@/lib/supabase/server';
-import { redirect } from 'next/navigation';
-import OnboardingForm from '@/components/onboarding-form';
-import { Card, CardHeader, CardTitle } from '@/components/ui/card';
-import Link from 'next/link';
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import OnboardingForm from '@/components/onboarding-form'
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
+import { getQueryClient } from '@/components/providers/get-query-client'
+import { fetchOrganizations } from '@/queries/organizations'
+import OrganizationsList from '@/components/organizations-list'
 
 export default async function AppPage() {
-  const supabase = await createClient();
+  const supabase = await createClient()
   const {
     data: { user },
-  } = await supabase.auth.getUser();
+  } = await supabase.auth.getUser()
 
   if (!user) {
-    redirect('/auth/login');
+    redirect('/auth/login')
   }
 
-  const { data: organizations } = await supabase
-    .from('organizations')
-    .select('id, name');
+  const queryClient = getQueryClient()
+  await queryClient.prefetchQuery({
+    queryKey: ['organizations'],
+    queryFn: fetchOrganizations,
+  })
 
+  const organizations = queryClient.getQueryData<any[]>(['organizations'])
   if (!organizations || organizations.length === 0) {
     return (
       <div className='flex min-h-svh w-full items-center justify-center p-6'>
@@ -25,29 +30,17 @@ export default async function AppPage() {
           <OnboardingForm />
         </div>
       </div>
-    );
+    )
   }
 
-  // if (organizations.length === 1) {
-  //   redirect(`/app/${organizations[0].id}`);
-  // }
-
   return (
-    <div className='min-h-svh bg-background'>
-      <div className='container mx-auto p-6'>
-        <h1 className='mb-6 text-3xl font-bold'>Select Organization</h1>
-        <div className='grid gap-6 sm:grid-cols-2 md:grid-cols-3'>
-          {organizations?.map((org) => (
-            <Card key={org.id} className='hover:bg-muted'>
-              <Link href={`/app/${org.id}`} className='block p-4'>
-                <CardHeader className='p-0'>
-                  <CardTitle>{org.name}</CardTitle>
-                </CardHeader>
-              </Link>
-            </Card>
-          ))}
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <div className='min-h-svh bg-background'>
+        <div className='container mx-auto p-6'>
+          <h1 className='mb-6 text-3xl font-bold'>Select Organization</h1>
+          <OrganizationsList />
         </div>
       </div>
-    </div>
-  );
+    </HydrationBoundary>
+  )
 }

--- a/src/components/organizations-list.tsx
+++ b/src/components/organizations-list.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import Link from 'next/link'
+import { fetchOrganizations } from '@/queries/organizations'
+import { Card, CardHeader, CardTitle } from '@/components/ui/card'
+
+export default function OrganizationsList() {
+  const { data: organizations = [] } = useQuery({
+    queryKey: ['organizations'],
+    queryFn: fetchOrganizations,
+  })
+
+  return (
+    <div className='grid gap-6 sm:grid-cols-2 md:grid-cols-3'>
+      {organizations.map((org) => (
+        <Card key={org.id} className='hover:bg-muted'>
+          <Link href={`/app/${org.id}`} className='block p-4'>
+            <CardHeader className='p-0'>
+              <CardTitle>{org.name}</CardTitle>
+            </CardHeader>
+          </Link>
+        </Card>
+      ))}
+    </div>
+  )
+}

--- a/src/components/posts-table.tsx
+++ b/src/components/posts-table.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { fetchPosts } from '@/queries/posts'
+import { DataTable } from '@/components/data-table/data-table'
+import { columns, type Post } from '@/app/app/[org_id]/[team_id]/posts/columns'
+
+export default function PostsTable({
+  orgId,
+  teamId,
+}: {
+  orgId: string
+  teamId: string
+}) {
+  const { data = [] } = useQuery({
+    queryKey: ['posts', orgId, teamId],
+    queryFn: () => fetchPosts(orgId, teamId),
+  })
+
+  return <DataTable columns={columns} data={data as Post[]} />
+}

--- a/src/components/recent-posts-client.tsx
+++ b/src/components/recent-posts-client.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { fetchPosts } from '@/queries/posts'
+import { Badge } from '@/components/ui/badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { CalendarIcon, FileTextIcon } from 'lucide-react'
+
+interface RecentPostsClientProps {
+  orgId: string
+  teamId: string
+}
+
+export default function RecentPostsClient({ orgId, teamId }: RecentPostsClientProps) {
+  const { data: posts, error } = useQuery({
+    queryKey: ['posts', orgId, teamId],
+    queryFn: () => fetchPosts(orgId, teamId),
+  })
+
+  if (error) {
+    return <div>Error loading posts</div>
+  }
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'published':
+        return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100'
+      case 'draft':
+        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-100'
+      case 'archived':
+        return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-100'
+      default:
+        return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-100'
+    }
+  }
+
+  const getPostTypeIcon = (type: string) => {
+    switch (type) {
+      case 'article':
+        return <FileTextIcon className='h-4 w-4' />
+      case 'announcement':
+        return <CalendarIcon className='h-4 w-4' />
+      default:
+        return <FileTextIcon className='h-4 w-4' />
+    }
+  }
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
+
+  const truncateContent = (content: string, maxLength: number = 150) => {
+    if (content.length <= maxLength) return content
+    return content.substring(0, maxLength) + '...'
+  }
+
+  if (!posts || posts.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className='flex items-center gap-2'>
+            <FileTextIcon className='h-5 w-5' />
+            Recent Posts
+          </CardTitle>
+          <CardDescription>Your team&apos;s latest posts</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className='text-muted-foreground text-center py-8'>
+            No posts yet. Create your first post to get started!
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className='flex items-center gap-2'>
+          <FileTextIcon className='h-5 w-5' />
+          Recent Posts
+        </CardTitle>
+        <CardDescription>Your team&apos;s latest posts</CardDescription>
+      </CardHeader>
+      <CardContent className='space-y-4'>
+        {posts.map((post) => (
+          <div
+            key={post.id}
+            className='flex flex-col space-y-2 p-4 rounded-lg border bg-card/50 hover:bg-card/80 transition-colors'
+          >
+            <div className='flex items-start justify-between'>
+              <div className='flex-1'>
+                <div className='flex items-center gap-2 mb-2'>
+                  {getPostTypeIcon(post.post_type)}
+                  <h3 className='font-medium text-sm'>{post.title}</h3>
+                  <Badge
+                    variant='secondary'
+                    className={`text-xs ${getStatusColor(post.post_status)}`}
+                  >
+                    {post.post_status}
+                  </Badge>
+                </div>
+                <p className='text-muted-foreground text-sm mb-2'>
+                  {truncateContent(post.content)}
+                </p>
+                <div className='flex items-center gap-4 text-xs text-muted-foreground'>
+                  <span className='flex items-center gap-1'>
+                    <CalendarIcon className='h-3 w-3' />
+                    {formatDate(post.created_at)}
+                  </span>
+                  <span className='capitalize'>{post.post_type}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/recent-posts.tsx
+++ b/src/components/recent-posts.tsx
@@ -1,148 +1,23 @@
-import { createClient } from '@/lib/supabase/server';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { CalendarIcon, FileTextIcon } from 'lucide-react';
-
-interface Post {
-  id: string;
-  title: string;
-  content: string;
-  post_status: 'draft' | 'published' | 'archived';
-  post_type: string;
-  created_at: string;
-  updated_at: string | null;
-  slug: string;
-}
+import { getQueryClient } from '@/components/providers/get-query-client'
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
+import RecentPostsClient from './recent-posts-client'
+import { fetchPosts } from '@/queries/posts'
 
 interface RecentPostsProps {
-  orgId: string;
-  teamId: string;
+  orgId: string
+  teamId: string
 }
 
 export async function RecentPosts({ orgId, teamId }: RecentPostsProps) {
-  const supabase = await createClient();
-
-  const { data: posts, error } = await supabase
-    .from('posts')
-    .select(
-      'id, title, content, post_status, post_type, created_at, updated_at, slug'
-    )
-    .eq('org_id', orgId)
-    .eq('team_id', teamId)
-    .order('created_at', { ascending: false })
-    .limit(10);
-
-  if (error) {
-    console.error('Error fetching posts:', error);
-    return <div>Error loading posts</div>;
-  }
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'published':
-        return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100';
-      case 'draft':
-        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-100';
-      case 'archived':
-        return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-100';
-      default:
-        return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-100';
-    }
-  };
-
-  const getPostTypeIcon = (type: string) => {
-    switch (type) {
-      case 'article':
-        return <FileTextIcon className='h-4 w-4' />;
-      case 'announcement':
-        return <CalendarIcon className='h-4 w-4' />;
-      default:
-        return <FileTextIcon className='h-4 w-4' />;
-    }
-  };
-
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  };
-
-  const truncateContent = (content: string, maxLength: number = 150) => {
-    if (content.length <= maxLength) return content;
-    return content.substring(0, maxLength) + '...';
-  };
-
-  if (!posts || posts.length === 0) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle className='flex items-center gap-2'>
-            <FileTextIcon className='h-5 w-5' />
-            Recent Posts
-          </CardTitle>
-          <CardDescription>Your team&apos;s latest posts</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <p className='text-muted-foreground text-center py-8'>
-            No posts yet. Create your first post to get started!
-          </p>
-        </CardContent>
-      </Card>
-    );
-  }
+  const queryClient = getQueryClient()
+  await queryClient.prefetchQuery({
+    queryKey: ['posts', orgId, teamId],
+    queryFn: () => fetchPosts(orgId, teamId),
+  })
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className='flex items-center gap-2'>
-          <FileTextIcon className='h-5 w-5' />
-          Recent Posts
-        </CardTitle>
-        <CardDescription>Your team&apos;s latest posts</CardDescription>
-      </CardHeader>
-      <CardContent className='space-y-4'>
-        {posts.map((post: Post) => (
-          <div
-            key={post.id}
-            className='flex flex-col space-y-2 p-4 rounded-lg border bg-card/50 hover:bg-card/80 transition-colors'
-          >
-            <div className='flex items-start justify-between'>
-              <div className='flex-1'>
-                <div className='flex items-center gap-2 mb-2'>
-                  {getPostTypeIcon(post.post_type)}
-                  <h3 className='font-medium text-sm'>{post.title}</h3>
-                  <Badge
-                    variant='secondary'
-                    className={`text-xs ${getStatusColor(post.post_status)}`}
-                  >
-                    {post.post_status}
-                  </Badge>
-                </div>
-                <p className='text-muted-foreground text-sm mb-2'>
-                  {truncateContent(post.content)}
-                </p>
-                <div className='flex items-center gap-4 text-xs text-muted-foreground'>
-                  <span className='flex items-center gap-1'>
-                    <CalendarIcon className='h-3 w-3' />
-                    {formatDate(post.created_at)}
-                  </span>
-                  <span className='capitalize'>{post.post_type}</span>
-                </div>
-              </div>
-            </div>
-          </div>
-        ))}
-      </CardContent>
-    </Card>
-  );
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <RecentPostsClient orgId={orgId} teamId={teamId} />
+    </HydrationBoundary>
+  )
 }

--- a/src/queries/organizations.ts
+++ b/src/queries/organizations.ts
@@ -1,0 +1,54 @@
+import { createClient as createServerClient } from '@/lib/supabase/server'
+import { createClient as createBrowserClient } from '@/lib/supabase/client'
+
+export async function fetchOrganizations() {
+  const supabase = await createServerClient()
+  const { data, error } = await supabase.from('organizations').select('id, name')
+  if (error) throw new Error(error.message)
+  return data
+}
+
+export async function fetchOrganization(orgId: string) {
+  const supabase = await createServerClient()
+  const { data, error } = await supabase
+    .from('organizations')
+    .select('*')
+    .eq('id', orgId)
+    .single()
+  if (error) throw new Error(error.message)
+  return data
+}
+
+export async function updateOrganization(orgId: string, name: string) {
+  const supabase = createBrowserClient()
+  const { error } = await supabase
+    .from('organizations')
+    .update({ name })
+    .eq('id', orgId)
+  if (error) throw new Error(error.message)
+}
+
+export async function deleteOrganization(orgId: string) {
+  const supabase = createBrowserClient()
+  const { error } = await supabase.from('organizations').delete().eq('id', orgId)
+  if (error) throw new Error(error.message)
+}
+
+export async function createOrganizationAndTeam(orgName: string, teamName: string) {
+  const supabase = createBrowserClient()
+  const { data: newOrgId, error: orgError } = await supabase.rpc(
+    'create_organization_and_add_current_user_as_owner',
+    { name: orgName }
+  )
+  if (orgError || !newOrgId) {
+    throw new Error(orgError?.message ?? 'Failed to create organization')
+  }
+  const { data: newTeamId, error: teamError } = await supabase.rpc(
+    'create_team_and_add_current_user_as_owner',
+    { team_name: teamName, org_id: newOrgId }
+  )
+  if (teamError || !newTeamId) {
+    throw new Error(teamError?.message ?? 'Failed to create team')
+  }
+  return { orgId: newOrgId, teamId: newTeamId }
+}

--- a/src/queries/posts.ts
+++ b/src/queries/posts.ts
@@ -1,0 +1,55 @@
+import { createClient as createServerClient } from '@/lib/supabase/server'
+import { createClient as createBrowserClient } from '@/lib/supabase/client'
+
+export async function fetchPosts(orgId: string, teamId: string) {
+  const supabase = await createServerClient()
+  const { data, error } = await supabase
+    .from('posts')
+    .select('*')
+    .eq('org_id', orgId)
+    .eq('team_id', teamId)
+    .order('created_at', { ascending: false })
+  if (error) throw new Error(error.message)
+  return data
+}
+
+export async function fetchPost(postId: string) {
+  const supabase = await createServerClient()
+  const { data, error } = await supabase
+    .from('posts')
+    .select('*')
+    .eq('id', postId)
+    .single()
+  if (error) throw new Error(error.message)
+  return data
+}
+
+export async function createPost(input: {
+  title: string
+  content: string
+  slug: string
+  post_type: string
+  org_id: string
+  team_id: string
+}) {
+  const supabase = createBrowserClient()
+  const { error } = await supabase.from('posts').insert({
+    title: input.title,
+    content: input.content,
+    post_type: input.post_type,
+    slug: input.slug,
+    org_id: input.org_id,
+    team_id: input.team_id,
+    post_status: 'draft',
+  })
+  if (error) throw new Error(error.message)
+}
+
+export async function updatePostContent(postId: string, content: string) {
+  const supabase = createBrowserClient()
+  const { error } = await supabase
+    .from('posts')
+    .update({ content })
+    .eq('id', postId)
+  if (error) throw new Error(error.message)
+}


### PR DESCRIPTION
## Summary
- centralize Supabase logic for posts and organizations under `src/queries`
- create API route to revalidate cache tags
- add client components for posts and org lists using React Query
- prefetch queries in server components and hydrate on the client
- refactor mutations to use React Query with revalidation

## Testing
- `pnpm install`
- `npm run lint` *(fails: Failed to load config "@tanstack/eslint-plugin-query" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_6844ad54af68832fa1b5e38a6fbcf4d0