### PR TITLE
Refactor queries into api object

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,15 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Data Access Helpers
+
+Query functions are grouped under the `api` object. For example:
+
+```ts
+import { api } from '@/queries'
+const posts = await api.posts.getAll(supabase, orgId, teamId)
+const org = await api.organizations.getById(supabase, orgId)
+```
+
+This replaces the previous flat function imports.

--- a/src/app/app/[org_id]/[team_id]/posts/page.tsx
+++ b/src/app/app/[org_id]/[team_id]/posts/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
 import { getQueryClient } from '@/components/providers/get-query-client'
-import { fetchPosts } from '@/queries/posts'
+import { api } from '@/queries'
 import PostsTable from '@/components/posts-table'
 
 export default async function Page({
@@ -19,8 +19,8 @@ export default async function Page({
 
   const queryClient = getQueryClient()
   await queryClient.prefetchQuery({
-    queryKey: ['posts', org_id, team_id],
-    queryFn: () => fetchPosts(org_id, team_id),
+    queryKey: ['posts', org_id, team_id, supabase],
+    queryFn: () => api.posts.getAll(supabase, org_id, team_id),
   })
 
   return (

--- a/src/app/app/[org_id]/[team_id]/settings/page.tsx
+++ b/src/app/app/[org_id]/[team_id]/settings/page.tsx
@@ -4,7 +4,7 @@ import UpdateOrganizationForm from '@/components/update-organization-form'
 import { DeleteOrganizationButton } from '@/components/delete-organization-button'
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
 import { getQueryClient } from '@/components/providers/get-query-client'
-import { fetchOrganization } from '@/queries/organizations'
+import { api } from '@/queries'
 
 export default async function OrganizationSettingsPage({
   params,
@@ -23,8 +23,8 @@ export default async function OrganizationSettingsPage({
 
   const queryClient = getQueryClient()
   await queryClient.prefetchQuery({
-    queryKey: ['organization', org_id],
-    queryFn: () => fetchOrganization(org_id),
+    queryKey: ['organization', org_id, supabase],
+    queryFn: () => api.organizations.getById(supabase, org_id),
   })
 
   return (

--- a/src/app/app/[org_id]/settings/page.tsx
+++ b/src/app/app/[org_id]/settings/page.tsx
@@ -4,7 +4,7 @@ import UpdateOrganizationForm from '@/components/update-organization-form'
 import { DeleteOrganizationButton } from '@/components/delete-organization-button'
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
 import { getQueryClient } from '@/components/providers/get-query-client'
-import { fetchOrganization } from '@/queries/organizations'
+import { api } from '@/queries'
 
 export default async function OrganizationSettingsPage({
   params,
@@ -23,8 +23,8 @@ export default async function OrganizationSettingsPage({
 
   const queryClient = getQueryClient()
   await queryClient.prefetchQuery({
-    queryKey: ['organization', org_id],
-    queryFn: () => fetchOrganization(org_id),
+    queryKey: ['organization', org_id, supabase],
+    queryFn: () => api.organizations.getById(supabase, org_id),
   })
 
   return (

--- a/src/components/create-post-modal.tsx
+++ b/src/components/create-post-modal.tsx
@@ -17,7 +17,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { PlusIcon } from 'lucide-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { createPost } from '@/queries/posts';
+import { api } from '@/queries';
 import { createClient as createBrowserClient } from '@/lib/supabase/client';
 
 interface CreatePostModalProps {
@@ -42,7 +42,7 @@ export function CreatePostModal({ orgId, teamId }: CreatePostModalProps) {
 
   const mutation = useMutation({
     mutationFn: () =>
-      createPost(supabase, {
+      api.posts.create(supabase, {
         title,
         content,
         post_type: postType,

--- a/src/components/delete-organization-button.tsx
+++ b/src/components/delete-organization-button.tsx
@@ -16,7 +16,7 @@ import {
   AlertDialogAction,
 } from '@/components/ui/alert-dialog'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { deleteOrganization } from '@/queries/organizations'
+import { api } from '@/queries'
 
 export function DeleteOrganizationButton({ orgId }: { orgId: string }) {
   const [value, setValue] = useState('')
@@ -25,7 +25,7 @@ export function DeleteOrganizationButton({ orgId }: { orgId: string }) {
   const queryClient = useQueryClient()
 
   const mutation = useMutation({
-    mutationFn: () => deleteOrganization(orgId),
+    mutationFn: () => api.organizations.remove(orgId),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ['organizations'] })
       await fetch('/api/revalidate-tag', {

--- a/src/components/onboarding-form.tsx
+++ b/src/components/onboarding-form.tsx
@@ -13,7 +13,7 @@ import {
   FormMessage,
 } from '@/components/ui/form'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { createOrganizationAndTeam } from '@/queries/organizations'
+import { api } from '@/queries'
 
 interface FormValues {
   orgName: string
@@ -29,7 +29,7 @@ export default function OnboardingForm() {
 
   const mutation = useMutation({
     mutationFn: (values: FormValues) =>
-      createOrganizationAndTeam(values.orgName, values.teamName),
+      api.organizations.createWithTeam(values.orgName, values.teamName),
     onSuccess: async (data) => {
       await queryClient.invalidateQueries({ queryKey: ['organizations'] })
       await fetch('/api/revalidate-tag', {

--- a/src/components/post-editor.tsx
+++ b/src/components/post-editor.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { EditorRoot, EditorContent, useEditor, StarterKit } from 'novel';
 import { Button } from '@/components/ui/button';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { updatePostContent } from '@/queries/posts';
+import { api } from '@/queries';
 import { createClient as createBrowserClient } from '@/lib/supabase/client';
 
 interface PostEditorProps {
@@ -23,7 +23,7 @@ export default function PostEditor({
 
   const mutation = useMutation({
     mutationFn: (content: string) =>
-      updatePostContent(supabase, postId, content),
+      api.posts.updateContent(supabase, postId, content),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ['post', postId] });
       await fetch('/api/revalidate-tag', {

--- a/src/components/posts-table.tsx
+++ b/src/components/posts-table.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { getPosts } from '@/queries/posts';
+import { api } from '@/queries';
 import { DataTable } from '@/components/data-table/data-table';
 import { columns, type Post } from '@/app/app/[org_id]/[team_id]/posts/columns';
 import { createClient as createBrowserClient } from '@/lib/supabase/client';
@@ -16,7 +16,7 @@ export default function PostsTable({
   const supabase = createBrowserClient();
   const { data = [] } = useQuery({
     queryKey: ['posts', orgId, teamId, supabase],
-    queryFn: () => getPosts(supabase, orgId, teamId),
+    queryFn: () => api.posts.getAll(supabase, orgId, teamId),
   });
 
   return <DataTable columns={columns} data={data as Post[]} />;

--- a/src/components/recent-posts-client.tsx
+++ b/src/components/recent-posts-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { getPosts } from '@/queries/posts';
+import { api } from '@/queries';
 import { Badge } from '@/components/ui/badge';
 import {
   Card,
@@ -29,7 +29,7 @@ export default function RecentPostsClient({
     isLoading,
   } = useQuery({
     queryKey: ['posts', orgId, teamId, supabase],
-    queryFn: () => getPosts(supabase, orgId, teamId),
+    queryFn: () => api.posts.getAll(supabase, orgId, teamId),
   });
 
   if (isLoading) {

--- a/src/components/recent-posts.tsx
+++ b/src/components/recent-posts.tsx
@@ -1,7 +1,7 @@
 import { getQueryClient } from '@/components/providers/get-query-client';
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 import RecentPostsClient from './recent-posts-client';
-import { getPosts } from '@/queries/posts';
+import { api } from '@/queries';
 import { createClient as createBrowserClient } from '@/lib/supabase/client';
 
 interface RecentPostsProps {
@@ -14,7 +14,7 @@ export async function RecentPosts({ orgId, teamId }: RecentPostsProps) {
   const queryClient = getQueryClient();
   await queryClient.prefetchQuery({
     queryKey: ['posts', orgId, teamId, supabase],
-    queryFn: () => getPosts(supabase, orgId, teamId),
+    queryFn: () => api.posts.getAll(supabase, orgId, teamId),
   });
 
   return (

--- a/src/components/update-organization-form.tsx
+++ b/src/components/update-organization-form.tsx
@@ -13,9 +13,8 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { updateOrganization } from '@/queries/organizations';
+import { api } from '@/queries';
 import { createClient as createBrowserClient } from '@/lib/supabase/client';
-import { fetchOrganization } from '@/queries/organizations';
 
 interface UpdateOrganizationFormProps {
   orgId: string;
@@ -32,7 +31,7 @@ export default function UpdateOrganizationForm({
   const supabase = createBrowserClient();
   const { data: organization } = useQuery({
     queryKey: ['organization', orgId, supabase],
-    queryFn: () => fetchOrganization(supabase, { id: orgId }),
+    queryFn: () => api.organizations.getById(supabase, orgId),
   });
 
   const form = useForm<FormValues>({
@@ -47,7 +46,7 @@ export default function UpdateOrganizationForm({
   const [success, setSuccess] = useState<string | null>(null);
 
   const mutation = useMutation({
-    mutationFn: (values: FormValues) => updateOrganization(orgId, values.name),
+    mutationFn: (values: FormValues) => api.organizations.update(orgId, values.name),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: ['organization', orgId],

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,0 +1,9 @@
+import { posts } from './posts'
+import { organizations } from './organizations'
+
+export const api = {
+  posts,
+  organizations,
+} as const
+
+export type Api = typeof api

--- a/src/queries/organizations.ts
+++ b/src/queries/organizations.ts
@@ -1,4 +1,3 @@
-import { createClient as createServerClient } from '@/lib/supabase/server'
 import { createClient as createBrowserClient } from '@/lib/supabase/client'
 import type { Database } from '@/lib/database.types'
 import type { SupabaseClient } from '@supabase/supabase-js'
@@ -22,31 +21,23 @@ export const usePosts = (supabaseEntityClient: SupabaseEntityClient<Database>, o
   }))
 }
 
-export async function fetchOrganizations(supabase: SupabaseClient<Database>, filters?: Record<string, unknown>) {
-  let query = supabase.from('organizations').select('id, name')
-  if (filters) {
-    Object.entries(filters).forEach(([key, value]) => {
-      query = query.eq(key, value as string)
-    })
-  }
-  const { data, error } = await query
+async function getAll(supabase: SupabaseClient<Database>) {
+  const { data, error } = await supabase.from('organizations').select('*')
   if (error) throw new Error(error.message)
   return data
 }
 
-export async function fetchOrganization(supabase: SupabaseClient<Database>, filters?: Record<string, unknown>) {
-  let query = supabase.from('organizations').select('*')
-  if (filters) {
-    Object.entries(filters).forEach(([key, value]) => {
-      query = query.eq(key, value as string)
-    })
-  }
-  const { data, error } = await query
+async function getById(supabase: SupabaseClient<Database>, id: string) {
+  const { data, error } = await supabase
+    .from('organizations')
+    .select('*')
+    .eq('id', id)
+    .single()
   if (error) throw new Error(error.message)
   return data
 }
 
-export async function updateOrganization(orgId: string, name: string) {
+async function update(orgId: string, name: string) {
   const supabase = createBrowserClient()
   const { error } = await supabase
     .from('organizations')
@@ -55,13 +46,13 @@ export async function updateOrganization(orgId: string, name: string) {
   if (error) throw new Error(error.message)
 }
 
-export async function deleteOrganization(orgId: string) {
+async function remove(orgId: string) {
   const supabase = createBrowserClient()
   const { error } = await supabase.from('organizations').delete().eq('id', orgId)
   if (error) throw new Error(error.message)
 }
 
-export async function createOrganizationAndTeam(orgName: string, teamName: string) {
+async function createWithTeam(orgName: string, teamName: string) {
   const supabase = createBrowserClient()
   const { data: newOrgId, error: orgError } = await supabase.rpc(
     'create_organization_and_add_current_user_as_owner',
@@ -79,3 +70,11 @@ export async function createOrganizationAndTeam(orgName: string, teamName: strin
   }
   return { orgId: newOrgId, teamId: newTeamId }
 }
+
+export const organizations = {
+  getAll,
+  getById,
+  update,
+  remove,
+  createWithTeam,
+} as const

--- a/src/queries/posts.ts
+++ b/src/queries/posts.ts
@@ -1,24 +1,11 @@
 import type { Database } from '@/lib/database.types'
 import type { SupabaseClient } from '@supabase/supabase-js'
 
-export async function getOrganizations(supabase: SupabaseClient<Database>) {
-  const { data, error } = await supabase
-    .from('organizations')
-    .select('*')
-  if (error) throw new Error(error.message)
-  return data
-}
-
-export async function getOrganization(supabase: SupabaseClient<Database>, orgId: string) {
-  const { data, error } = await supabase
-    .from('organizations')
-    .select('*')
-    .eq('id', orgId)
-  if (error) throw new Error(error.message)
-  return data
-}
-
-export async function getPosts(supabase: SupabaseClient<Database>, orgId: string, teamId: string) {
+async function getPosts(
+  supabase: SupabaseClient<Database>,
+  orgId: string,
+  teamId: string
+) {
   const { data, error } = await supabase
     .from('posts')
     .select('*')
@@ -29,7 +16,7 @@ export async function getPosts(supabase: SupabaseClient<Database>, orgId: string
   return data
 }
 
-export async function getPost(supabase: SupabaseClient<Database>, postId: string) {
+async function getPost(supabase: SupabaseClient<Database>, postId: string) {
   const { data, error } = await supabase
     .from('posts')
     .select('*')
@@ -39,14 +26,16 @@ export async function getPost(supabase: SupabaseClient<Database>, postId: string
   return data
 }
 
-export async function createPost(supabase: SupabaseClient<Database>, input: {
-  title: string
-  content: string
-  slug: string
-  post_type: string
-  org_id: string
-  team_id: string
-}) {
+async function createPost(
+  supabase: SupabaseClient<Database>,
+  input: {
+    title: string
+    content: string
+    slug: string
+    post_type: string
+    org_id: string
+    team_id: string
+  }) {
   const { error } = await supabase.from('posts').insert({
     title: input.title,
     content: input.content,
@@ -59,10 +48,21 @@ export async function createPost(supabase: SupabaseClient<Database>, input: {
   if (error) throw new Error(error.message)
 }
 
-export async function updatePostContent(supabase: SupabaseClient<Database>, postId: string, content: string) {
+async function updatePostContent(
+  supabase: SupabaseClient<Database>,
+  postId: string,
+  content: string
+) {
   const { error } = await supabase
     .from('posts')
     .update({ content })
     .eq('id', postId)
   if (error) throw new Error(error.message)
 }
+
+export const posts = {
+  getAll: getPosts,
+  getById: getPost,
+  create: createPost,
+  updateContent: updatePostContent,
+} as const


### PR DESCRIPTION
## Summary
- group query helpers in `src/queries/index.ts`
- refactor post queries to use REST-like names
- refactor organization queries and add new names
- update components and pages to use the new `api` object
- document how to use the new helpers

## Testing
- `npm run lint`
- `npx tsc --noEmit` *(fails: Argument of type '"supajump.get_teams_for_current_user"' is not assignable...)*

------
https://chatgpt.com/codex/tasks/task_e_684665748d84832faff6529b2ae1d99b