### PR TITLE
Add React Query hooks and stable keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.6.0",
+    "fast-json-stable-stringify": "^2.1.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.511.0",
     "next": "15.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.1.0)
+      fast-json-stable-stringify:
+        specifier: ^2.1.0
+        version: 2.1.0
       input-otp:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)

--- a/src/app/app/[org_id]/[team_id]/posts/page.tsx
+++ b/src/app/app/[org_id]/[team_id]/posts/page.tsx
@@ -3,6 +3,7 @@ import { createClient } from '@/lib/supabase/server'
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
 import { getQueryClient } from '@/components/providers/get-query-client'
 import { api } from '@/queries'
+import { postsKeys } from '@/queries/keys'
 import PostsTable from '@/components/posts-table'
 
 export default async function Page({
@@ -19,7 +20,8 @@ export default async function Page({
 
   const queryClient = getQueryClient()
   await queryClient.prefetchQuery({
-    queryKey: ['posts', org_id, team_id, supabase],
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: [...postsKeys.list(org_id, team_id), supabase.supabaseUrl],
     queryFn: () => api.posts.getAll(supabase, org_id, team_id),
   })
 

--- a/src/app/app/[org_id]/[team_id]/settings/page.tsx
+++ b/src/app/app/[org_id]/[team_id]/settings/page.tsx
@@ -5,6 +5,7 @@ import { DeleteOrganizationButton } from '@/components/delete-organization-butto
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
 import { getQueryClient } from '@/components/providers/get-query-client'
 import { api } from '@/queries'
+import { organizationsKeys } from '@/queries/keys'
 
 export default async function OrganizationSettingsPage({
   params,
@@ -23,7 +24,8 @@ export default async function OrganizationSettingsPage({
 
   const queryClient = getQueryClient()
   await queryClient.prefetchQuery({
-    queryKey: ['organization', org_id, supabase],
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: [...organizationsKeys.detail(org_id), supabase.supabaseUrl],
     queryFn: () => api.organizations.getById(supabase, org_id),
   })
 

--- a/src/app/app/[org_id]/settings/page.tsx
+++ b/src/app/app/[org_id]/settings/page.tsx
@@ -5,6 +5,7 @@ import { DeleteOrganizationButton } from '@/components/delete-organization-butto
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query'
 import { getQueryClient } from '@/components/providers/get-query-client'
 import { api } from '@/queries'
+import { organizationsKeys } from '@/queries/keys'
 
 export default async function OrganizationSettingsPage({
   params,
@@ -23,7 +24,8 @@ export default async function OrganizationSettingsPage({
 
   const queryClient = getQueryClient()
   await queryClient.prefetchQuery({
-    queryKey: ['organization', org_id, supabase],
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: [...organizationsKeys.detail(org_id), supabase.supabaseUrl],
     queryFn: () => api.organizations.getById(supabase, org_id),
   })
 

--- a/src/components/create-post-modal.tsx
+++ b/src/components/create-post-modal.tsx
@@ -18,6 +18,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { PlusIcon } from 'lucide-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/queries';
+import { postsKeys } from '@/queries/keys';
 import { createClient as createBrowserClient } from '@/lib/supabase/client';
 
 interface CreatePostModalProps {
@@ -52,7 +53,7 @@ export function CreatePostModal({ orgId, teamId }: CreatePostModalProps) {
       }),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ['posts', orgId, teamId],
+        queryKey: postsKeys.list(orgId, teamId),
       });
       await fetch('/api/revalidate-tag', {
         method: 'POST',

--- a/src/components/delete-organization-button.tsx
+++ b/src/components/delete-organization-button.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/alert-dialog'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { api } from '@/queries'
+import { organizationsKeys } from '@/queries/keys'
 
 export function DeleteOrganizationButton({ orgId }: { orgId: string }) {
   const [value, setValue] = useState('')
@@ -27,7 +28,9 @@ export function DeleteOrganizationButton({ orgId }: { orgId: string }) {
   const mutation = useMutation({
     mutationFn: () => api.organizations.remove(orgId),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['organizations'] })
+      await queryClient.invalidateQueries({
+        queryKey: organizationsKeys.all(),
+      })
       await fetch('/api/revalidate-tag', {
         method: 'POST',
         body: JSON.stringify({ tag: 'organizations' }),

--- a/src/components/onboarding-form.tsx
+++ b/src/components/onboarding-form.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/form'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { api } from '@/queries'
+import { organizationsKeys } from '@/queries/keys'
 
 interface FormValues {
   orgName: string
@@ -31,7 +32,7 @@ export default function OnboardingForm() {
     mutationFn: (values: FormValues) =>
       api.organizations.createWithTeam(values.orgName, values.teamName),
     onSuccess: async (data) => {
-      await queryClient.invalidateQueries({ queryKey: ['organizations'] })
+      await queryClient.invalidateQueries({ queryKey: organizationsKeys.all() })
       await fetch('/api/revalidate-tag', {
         method: 'POST',
         body: JSON.stringify({ tag: 'organizations' }),

--- a/src/components/post-editor.tsx
+++ b/src/components/post-editor.tsx
@@ -5,6 +5,7 @@ import { EditorRoot, EditorContent, useEditor, StarterKit } from 'novel';
 import { Button } from '@/components/ui/button';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/queries';
+import { postsKeys } from '@/queries/keys';
 import { createClient as createBrowserClient } from '@/lib/supabase/client';
 
 interface PostEditorProps {
@@ -25,7 +26,9 @@ export default function PostEditor({
     mutationFn: (content: string) =>
       api.posts.updateContent(supabase, postId, content),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['post', postId] });
+      await queryClient.invalidateQueries({
+        queryKey: postsKeys.detail(postId),
+      });
       await fetch('/api/revalidate-tag', {
         method: 'POST',
         body: JSON.stringify({ tag: 'posts' }),

--- a/src/components/posts-table.tsx
+++ b/src/components/posts-table.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
-import { api } from '@/queries';
+import { usePosts } from '@/hooks/use-posts';
 import { DataTable } from '@/components/data-table/data-table';
 import { columns, type Post } from '@/app/app/[org_id]/[team_id]/posts/columns';
-import { createClient as createBrowserClient } from '@/lib/supabase/client';
 
 export default function PostsTable({
   orgId,
@@ -13,11 +11,7 @@ export default function PostsTable({
   orgId: string;
   teamId: string;
 }) {
-  const supabase = createBrowserClient();
-  const { data = [] } = useQuery({
-    queryKey: ['posts', orgId, teamId, supabase],
-    queryFn: () => api.posts.getAll(supabase, orgId, teamId),
-  });
+  const { data = [] } = usePosts(orgId, teamId);
 
   return <DataTable columns={columns} data={data as Post[]} />;
 }

--- a/src/components/recent-posts-client.tsx
+++ b/src/components/recent-posts-client.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
-import { api } from '@/queries';
+import { usePosts } from '@/hooks/use-posts';
 import { Badge } from '@/components/ui/badge';
 import {
   Card,
@@ -11,7 +10,6 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { CalendarIcon, FileTextIcon } from 'lucide-react';
-import { createClient as createBrowserClient } from '@/lib/supabase/client';
 
 interface RecentPostsClientProps {
   orgId: string;
@@ -22,15 +20,7 @@ export default function RecentPostsClient({
   orgId,
   teamId,
 }: RecentPostsClientProps) {
-  const supabase = createBrowserClient();
-  const {
-    data: posts,
-    error,
-    isLoading,
-  } = useQuery({
-    queryKey: ['posts', orgId, teamId, supabase],
-    queryFn: () => api.posts.getAll(supabase, orgId, teamId),
-  });
+  const { data: posts, error, isLoading } = usePosts(orgId, teamId);
 
   if (isLoading) {
     return <div>Loading...</div>;

--- a/src/components/recent-posts.tsx
+++ b/src/components/recent-posts.tsx
@@ -2,6 +2,7 @@ import { getQueryClient } from '@/components/providers/get-query-client';
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 import RecentPostsClient from './recent-posts-client';
 import { api } from '@/queries';
+import { postsKeys } from '@/queries/keys';
 import { createClient as createBrowserClient } from '@/lib/supabase/client';
 
 interface RecentPostsProps {
@@ -13,7 +14,8 @@ export async function RecentPosts({ orgId, teamId }: RecentPostsProps) {
   const supabase = createBrowserClient();
   const queryClient = getQueryClient();
   await queryClient.prefetchQuery({
-    queryKey: ['posts', orgId, teamId, supabase],
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: [...postsKeys.list(orgId, teamId), supabase.supabaseUrl],
     queryFn: () => api.posts.getAll(supabase, orgId, teamId),
   });
 

--- a/src/components/update-organization-form.tsx
+++ b/src/components/update-organization-form.tsx
@@ -12,9 +12,10 @@ import {
   FormControl,
   FormMessage,
 } from '@/components/ui/form';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/queries';
-import { createClient as createBrowserClient } from '@/lib/supabase/client';
+import { useOrganization } from '@/hooks/use-organization';
+import { organizationsKeys } from '@/queries/keys';
 
 interface UpdateOrganizationFormProps {
   orgId: string;
@@ -28,11 +29,7 @@ export default function UpdateOrganizationForm({
   orgId,
 }: UpdateOrganizationFormProps) {
   const queryClient = useQueryClient();
-  const supabase = createBrowserClient();
-  const { data: organization } = useQuery({
-    queryKey: ['organization', orgId, supabase],
-    queryFn: () => api.organizations.getById(supabase, orgId),
-  });
+  const { data: organization } = useOrganization(orgId);
 
   const form = useForm<FormValues>({
     defaultValues: { name: organization?.name ?? '' },
@@ -49,7 +46,7 @@ export default function UpdateOrganizationForm({
     mutationFn: (values: FormValues) => api.organizations.update(orgId, values.name),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ['organization', orgId],
+        queryKey: organizationsKeys.detail(orgId),
       });
       await fetch('/api/revalidate-tag', {
         method: 'POST',

--- a/src/hooks/use-organization.ts
+++ b/src/hooks/use-organization.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { createClient as createBrowserClient } from '@/lib/supabase/client';
+import { organizationsKeys } from '@/queries/keys';
+import { api } from '@/queries';
+
+export function useOrganization(orgId: string) {
+  const supabase = createBrowserClient();
+  return useQuery({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: [...organizationsKeys.detail(orgId), supabase.supabaseUrl],
+    queryFn: () => api.organizations.getById(supabase, orgId),
+  });
+}

--- a/src/hooks/use-posts.ts
+++ b/src/hooks/use-posts.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { createClient as createBrowserClient } from '@/lib/supabase/client';
+import { postsKeys } from '@/queries/keys';
+import { api } from '@/queries';
+
+export function usePosts(orgId: string, teamId: string) {
+  const supabase = createBrowserClient();
+  return useQuery({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: [...postsKeys.list(orgId, teamId), supabase.supabaseUrl],
+    queryFn: () => api.posts.getAll(supabase, orgId, teamId),
+  });
+}

--- a/src/queries/keys.ts
+++ b/src/queries/keys.ts
@@ -1,0 +1,10 @@
+export const postsKeys = {
+  all: () => ['posts'] as const,
+  list: (orgId: string, teamId: string) => ['posts', orgId, teamId] as const,
+  detail: (postId: string) => ['post', postId] as const,
+} as const;
+
+export const organizationsKeys = {
+  all: () => ['organizations'] as const,
+  detail: (orgId: string) => ['organization', orgId] as const,
+} as const;

--- a/src/queries/query-factory.ts
+++ b/src/queries/query-factory.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { entities } from './entities'
 import { queryOptions } from '@tanstack/react-query'
+import stringify from 'fast-json-stable-stringify'
 import { Database } from '@/lib/database.types'
 
 type EntityKey = keyof typeof entities
@@ -111,7 +112,7 @@ export function queryOptionsFactory<K extends keyof typeof entities>(
     options: QueryOpts<InferRowType<(typeof entities)[K]>> & { joins?: (keyof (typeof entities)[K]['joins'])[] }
   ) {
     return queryOptions({
-      queryKey: [table, options ],
+      queryKey: [table, stringify(options)],
       queryFn: () => supabaseEntityClient.findMany(table, options),
     })
   }


### PR DESCRIPTION
## Summary
- add stable query key utilities
- create hooks for posts and organizations
- use new hooks in components
- stabilize query options with fast-json-stable-stringify
- integrate new keys in server components

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68470bba82c4832f870d592adb5f0ca5