### PR TITLE
Add teams hooks

### DIFF
--- a/src/hooks/use-teams.ts
+++ b/src/hooks/use-teams.ts
@@ -1,0 +1,24 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { createClient as createBrowserClient } from '@/lib/supabase/client'
+import { teamsKeys } from '@/queries/keys'
+import { api } from '@/queries'
+
+export function useTeams(orgId: string) {
+  const supabase = createBrowserClient()
+  return useQuery({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: [...teamsKeys.list(orgId), supabase.supabaseUrl],
+    queryFn: () => api.teams.getAll(supabase, orgId),
+  })
+}
+
+export function useTeam(teamId: string) {
+  const supabase = createBrowserClient()
+  return useQuery({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: [...teamsKeys.detail(teamId), supabase.supabaseUrl],
+    queryFn: () => api.teams.getById(supabase, teamId),
+  })
+}

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,9 +1,11 @@
 import { posts } from './posts'
 import { organizations } from './organizations'
+import { teams } from './teams'
 
 export const api = {
   posts,
   organizations,
+  teams,
 } as const
 
 export type Api = typeof api

--- a/src/queries/keys.ts
+++ b/src/queries/keys.ts
@@ -8,3 +8,9 @@ export const organizationsKeys = {
   all: () => ['organizations'] as const,
   detail: (orgId: string) => ['organization', orgId] as const,
 } as const;
+
+export const teamsKeys = {
+  all: () => ['teams'] as const,
+  list: (orgId: string) => ['teams', orgId] as const,
+  detail: (teamId: string) => ['team', teamId] as const,
+} as const;

--- a/src/queries/teams.ts
+++ b/src/queries/teams.ts
@@ -1,0 +1,30 @@
+import type { Database } from '@/lib/database.types'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+async function getTeams(
+  supabase: SupabaseClient<Database>,
+  orgId: string
+) {
+  const { data, error } = await supabase
+    .from('teams')
+    .select('*')
+    .eq('org_id', orgId)
+    .order('name', { ascending: true })
+  if (error) throw new Error(error.message)
+  return data
+}
+
+async function getTeam(supabase: SupabaseClient<Database>, teamId: string) {
+  const { data, error } = await supabase
+    .from('teams')
+    .select('*')
+    .eq('id', teamId)
+    .single()
+  if (error) throw new Error(error.message)
+  return data
+}
+
+export const teams = {
+  getAll: getTeams,
+  getById: getTeam,
+} as const


### PR DESCRIPTION
## Summary
- add teams queries and React Query hooks for `useTeams` and `useTeam`
- export new teams API and query keys

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849eae5fe50832fbe041eba7d7028e9