### PR TITLE
Improve organization/team card details

### DIFF
--- a/src/components/organizations-list.tsx
+++ b/src/components/organizations-list.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import Link from 'next/link';
-import { Card, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
 import { useOrganizations } from '@/queries/organizations';
 import { SupabaseEntityClient } from '@/queries/query-factory';
 import { createClient as createBrowserClient } from '@/lib/supabase/client';
@@ -23,12 +29,29 @@ export function OrganizationsList() {
       {organizations.data?.map((org) => {
         const organization =
           org as (typeof entities)['organizations']['rowType'] & { id: string };
+        const createdAt = organization.created_at
+          ? new Date(organization.created_at).toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+            })
+          : null;
         return (
           <Card key={organization.id} className='hover:bg-muted'>
-            <Link href={`/app/${organization.id}`} className='block p-4'>
+            <Link href={`/app/${organization.id}`} className='block space-y-2 p-4'>
               <CardHeader className='p-0'>
                 <CardTitle>{organization.name}</CardTitle>
+                {organization.type && (
+                  <CardDescription className='capitalize'>
+                    {organization.type}
+                  </CardDescription>
+                )}
               </CardHeader>
+              {createdAt && (
+                <CardContent className='p-0 text-sm text-muted-foreground'>
+                  Created {createdAt}
+                </CardContent>
+              )}
             </Link>
           </Card>
         );

--- a/src/components/teams-list.tsx
+++ b/src/components/teams-list.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import Link from 'next/link';
-import { Card, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
 import { useTeams } from '@/queries/teams';
 import { SupabaseEntityClient } from '@/queries/query-factory';
 import { createClient as createBrowserClient } from '@/lib/supabase/client';
@@ -15,6 +21,7 @@ export function TeamsList() {
     {
       filters: {},
       sort: 'name',
+      joins: ['organization'],
     }
   );
 
@@ -23,16 +30,32 @@ export function TeamsList() {
       {teams.data?.map((team) => {
         const teamData = team as (typeof entities)['teams']['rowType'] & {
           id: string;
+          organizations?: { id: string; name: string } | null;
         };
+        const createdAt = teamData.created_at
+          ? new Date(teamData.created_at).toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+            })
+          : null;
         return (
           <Card key={teamData.id} className='hover:bg-muted'>
             <Link
               href={`/app/${teamData.org_id}/${teamData.id}/dashboard`}
-              className='block p-4'
+              className='block space-y-2 p-4'
             >
               <CardHeader className='p-0'>
                 <CardTitle>{teamData.name}</CardTitle>
+                {teamData.organizations?.name && (
+                  <CardDescription>{teamData.organizations.name}</CardDescription>
+                )}
               </CardHeader>
+              {createdAt && (
+                <CardContent className='p-0 text-sm text-muted-foreground'>
+                  Created {createdAt}
+                </CardContent>
+              )}
             </Link>
           </Card>
         );


### PR DESCRIPTION
## Summary
- add description and creation info in `OrganizationsList` cards
- show parent organization and created date in `TeamsList` cards

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684af3a74818832fb2e1377a77751bb8