### PR TITLE
Improve delete actions

### DIFF
--- a/src/app/app/[org_id]/[team_id]/settings/page.tsx
+++ b/src/app/app/[org_id]/[team_id]/settings/page.tsx
@@ -35,7 +35,12 @@ export default async function OrganizationSettingsPage({
         <div className='container mx-auto p-6 max-w-xl space-y-10'>
           <h1 className='text-3xl font-bold'>Organization Settings</h1>
           <UpdateOrganizationForm orgId={org_id} />
-          <div className='pt-6 border-t'>
+          <div className='pt-6 border-t space-y-2'>
+            <h2 className='text-xl font-semibold text-destructive'>Danger Zone</h2>
+            <p className='text-sm text-muted-foreground'>
+              Deleting your organization removes all teams and related data
+              permanently.
+            </p>
             <DeleteOrganizationButton orgId={org_id} />
           </div>
         </div>

--- a/src/app/app/[org_id]/[team_id]/settings/team/page.tsx
+++ b/src/app/app/[org_id]/[team_id]/settings/team/page.tsx
@@ -29,7 +29,11 @@ export default async function TeamSettingsPage({
       <div className="container mx-auto p-6 max-w-xl space-y-10">
         <h1 className="text-3xl font-bold">Team Settings</h1>
         {team && <UpdateTeamForm team={team} />}
-        <div className="pt-6 border-t">
+        <div className="pt-6 border-t space-y-2">
+          <h2 className="text-xl font-semibold text-destructive">Danger Zone</h2>
+          <p className="text-sm text-muted-foreground">
+            Deleting this team will permanently remove its posts and data.
+          </p>
           <DeleteTeamButton orgId={org_id} teamId={team_id} />
         </div>
       </div>

--- a/src/app/app/[org_id]/settings/page.tsx
+++ b/src/app/app/[org_id]/settings/page.tsx
@@ -35,7 +35,12 @@ export default async function OrganizationSettingsPage({
         <div className='container mx-auto p-6 max-w-xl space-y-10'>
           <h1 className='text-3xl font-bold'>Organization Settings</h1>
           <UpdateOrganizationForm orgId={org_id} />
-          <div className='pt-6 border-t'>
+          <div className='pt-6 border-t space-y-2'>
+            <h2 className='text-xl font-semibold text-destructive'>Danger Zone</h2>
+            <p className='text-sm text-muted-foreground'>
+              Deleting your organization removes all teams and related data
+              permanently.
+            </p>
             <DeleteOrganizationButton orgId={org_id} />
           </div>
         </div>

--- a/src/components/delete-organization-button.tsx
+++ b/src/components/delete-organization-button.tsx
@@ -57,7 +57,9 @@ export function DeleteOrganizationButton({ orgId }: { orgId: string }) {
             <AlertDialogHeader>
               <AlertDialogTitle>Delete Organization</AlertDialogTitle>
               <AlertDialogDescription>
-                This action is irreversible. Type DELETE to continue.
+                Deleting this organization will remove every team and all
+                associated data. This action is irreversible. Type DELETE to
+                continue.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <Input value={value} onChange={(e) => setValue(e.target.value)} />

--- a/src/components/delete-team-button.tsx
+++ b/src/components/delete-team-button.tsx
@@ -48,7 +48,8 @@ export function DeleteTeamButton({ orgId, teamId }: { orgId: string; teamId: str
             <AlertDialogHeader>
               <AlertDialogTitle>Delete Team</AlertDialogTitle>
               <AlertDialogDescription>
-                This action is irreversible. Type DELETE to continue.
+                Deleting this team is permanent and will remove all of its posts
+                and data. Type DELETE to continue.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <Input value={value} onChange={(e) => setValue(e.target.value)} />


### PR DESCRIPTION
## Summary
- show Danger Zone info on team/org settings pages
- clarify warnings in DeleteTeamButton and DeleteOrganizationButton dialogs

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684b82afe9a8832f9c0bf10bd749b3ea