### PR TITLE
Implement team creation in OrgTeamSwitcher

### DIFF
--- a/src/components/create-team-dialog.tsx
+++ b/src/components/create-team-dialog.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { api } from '@/queries'
+import { organizationsKeys, teamsKeys } from '@/queries/keys'
+
+interface CreateTeamDialogProps {
+  orgId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+interface FormValues {
+  name: string
+}
+
+export default function CreateTeamDialog({ orgId, open, onOpenChange }: CreateTeamDialogProps) {
+  const form = useForm<FormValues>({ defaultValues: { name: '' } })
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useMutation({
+    mutationFn: (values: FormValues) => api.teams.create(orgId, values.name),
+    onSuccess: async (teamId: string) => {
+      await queryClient.invalidateQueries({ queryKey: organizationsKeys.allWithTeams() })
+      await queryClient.invalidateQueries({ queryKey: teamsKeys.list(orgId) })
+      await fetch('/api/revalidate-tag', {
+        method: 'POST',
+        body: JSON.stringify({ tag: 'teams' }),
+      })
+      form.reset()
+      onOpenChange(false)
+      router.push(`/app/${orgId}/${teamId}/dashboard`)
+    },
+    onError: (err: Error) => setError(err.message),
+  })
+
+  function onSubmit(values: FormValues) {
+    setError(null)
+    mutation.mutate(values)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Create Team</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              rules={{ required: 'Team name is required' }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input placeholder="My Team" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {error && <p className="text-sm text-red-500">{error}</p>}
+            <Button type="submit" className="w-full" disabled={mutation.isPending}>
+              {mutation.isPending ? 'Creating...' : 'Create Team'}
+            </Button>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/org-team-switcher.tsx
+++ b/src/components/org-team-switcher.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { ChevronsUpDown } from 'lucide-react';
+import { ChevronsUpDown, Plus } from 'lucide-react';
 
 import {
   CommandDialog,
@@ -17,6 +17,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from '@/components/ui/sidebar';
+import CreateTeamDialog from './create-team-dialog';
 import { usePathname, useRouter } from 'next/navigation';
 import { useOrganizationsWithTeams } from '@/hooks/use-organization';
 
@@ -25,6 +26,7 @@ export function OrgTeamSwitcher({ currentOrgId, currentTeamId }: { currentOrgId:
   const router = useRouter();
 
   const [open, setOpen] = React.useState(false);
+  const [createOpen, setCreateOpen] = React.useState(false);
 
   const { data: organizationsWithTeams = [] } = useOrganizationsWithTeams();
 
@@ -138,9 +140,14 @@ export function OrgTeamSwitcher({ currentOrgId, currentTeamId }: { currentOrgId:
                 {team.name}
               </CommandItem>
             ))}
+            <CommandSeparator />
+            <CommandItem onSelect={() => { setOpen(false); setCreateOpen(true) }}>
+              <Plus className='mr-2 size-4' /> Create Team
+            </CommandItem>
           </CommandGroup>
         </CommandList>
       </CommandDialog>
+      <CreateTeamDialog orgId={activeOrg.id} open={createOpen} onOpenChange={setCreateOpen} />
     </>
   );
 }

--- a/src/queries/teams.ts
+++ b/src/queries/teams.ts
@@ -3,6 +3,7 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 import { useQuery } from '@tanstack/react-query'
 import { queryOptionsFactory, QueryOpts, SupabaseEntityClient } from './query-factory'
 import { entities } from './entities'
+import { createClient as createBrowserClient } from '@/lib/supabase/client'
 
 export const useTeams = (supabaseEntityClient: SupabaseEntityClient<Database>, options: QueryOpts<typeof entities['teams']['rowType']> & { joins?: (keyof (typeof entities['teams']['joins'])[])[] }) => {
   return useQuery(queryOptionsFactory(supabaseEntityClient, 'teams', {
@@ -34,7 +35,20 @@ async function getTeam(supabase: SupabaseClient<Database>, teamId: string) {
   return data
 }
 
+async function createTeam(orgId: string, teamName: string) {
+  const supabase = createBrowserClient()
+  const { data, error } = await supabase.rpc(
+    'create_team_and_add_current_user_as_owner',
+    { team_name: teamName, org_id: orgId }
+  )
+  if (error || !data) {
+    throw new Error(error?.message ?? 'Failed to create team')
+  }
+  return data
+}
+
 export const teams = {
   getAll: getTeams,
   getById: getTeam,
+  create: createTeam,
 } as const


### PR DESCRIPTION
## Summary
- allow creating a team from the organization/team switcher
- implement `createTeam` API helper
- add `CreateTeamDialog` component for name input

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_684f97164c40832f917fb47061c1e993