### PR TITLE
Refactor members & roles pages

### DIFF
--- a/src/components/members-table.tsx
+++ b/src/components/members-table.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { useMembers } from '@/hooks/use-members';
+import { DataTable } from '@/components/data-table/data-table';
+import { columns, type Member } from '@/app/app/[org_id]/members/columns';
+
+export default function MembersTable({ orgId }: { orgId: string }) {
+  const { data = [] } = useMembers(orgId);
+  return <DataTable columns={columns} data={data as Member[]} />;
+}

--- a/src/components/roles-table.tsx
+++ b/src/components/roles-table.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { useRoles } from '@/hooks/use-roles';
+import { DataTable } from '@/components/data-table/data-table';
+import { columns, type Role } from '@/app/app/[org_id]/roles/columns';
+
+export default function RolesTable({ orgId }: { orgId: string }) {
+  const { data = [] } = useRoles(orgId);
+  return <DataTable columns={columns} data={data as Role[]} />;
+}

--- a/src/hooks/use-members.ts
+++ b/src/hooks/use-members.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { createClient as createBrowserClient } from '@/lib/supabase/client';
+import { membersKeys } from '@/queries/keys';
+import { api } from '@/queries';
+
+export function useMembers(orgId: string) {
+  const supabase = createBrowserClient();
+  return useQuery({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: membersKeys.list(orgId),
+    queryFn: () => api.members.getAll(supabase, orgId),
+  });
+}

--- a/src/hooks/use-roles.ts
+++ b/src/hooks/use-roles.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { createClient as createBrowserClient } from '@/lib/supabase/client';
+import { rolesKeys } from '@/queries/keys';
+import { api } from '@/queries';
+
+export function useRoles(orgId: string) {
+  const supabase = createBrowserClient();
+  return useQuery({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: rolesKeys.list(orgId),
+    queryFn: () => api.roles.getAll(supabase, orgId),
+  });
+}

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,11 +1,15 @@
 import { posts } from './posts'
 import { organizations } from './organizations'
 import { teams } from './teams'
+import { members } from './members'
+import { roles } from './roles'
 
 export const api = {
   posts,
   organizations,
   teams,
+  members,
+  roles,
 } as const
 
 export type Api = typeof api

--- a/src/queries/keys.ts
+++ b/src/queries/keys.ts
@@ -15,3 +15,13 @@ export const teamsKeys = {
   list: (orgId: string) => ['teams', orgId] as const,
   detail: (teamId: string) => ['team', teamId] as const,
 } as const;
+
+export const membersKeys = {
+  all: () => ['members'] as const,
+  list: (orgId: string) => ['members', orgId] as const,
+} as const;
+
+export const rolesKeys = {
+  all: () => ['roles'] as const,
+  list: (orgId: string) => ['roles', orgId] as const,
+} as const;

--- a/src/queries/members.ts
+++ b/src/queries/members.ts
@@ -1,0 +1,18 @@
+import type { Database } from '@/lib/database.types';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+async function getMembers(
+  supabase: SupabaseClient<Database>,
+  orgId: string,
+) {
+  const { data, error } = await supabase
+    .from('org_memberships')
+    .select('*, profiles!org_memberships_profiles_fkey(*)')
+    .eq('org_id', orgId);
+  if (error) throw new Error(error.message);
+  return (data ?? []).map((m) => m.profiles);
+}
+
+export const members = {
+  getAll: getMembers,
+} as const;

--- a/src/queries/roles.ts
+++ b/src/queries/roles.ts
@@ -1,0 +1,18 @@
+import type { Database } from '@/lib/database.types';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+async function getRoles(
+  supabase: SupabaseClient<Database>,
+  orgId: string,
+) {
+  const { data, error } = await supabase
+    .from('roles')
+    .select('*')
+    .eq('org_id', orgId);
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+export const roles = {
+  getAll: getRoles,
+} as const;


### PR DESCRIPTION
## Summary
- add members & roles query helpers and hooks
- create members-table and roles-table components
- refactor members and roles pages to use react-query hydration like posts page
- extend API object and query keys

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68534e4a790c832f9be721357547d452