### PR TITLE
Refactor pages to use API queries

### DIFF
--- a/src/app/app/[org_id]/[team_id]/posts/[postId]/page.tsx
+++ b/src/app/app/[org_id]/[team_id]/posts/[postId]/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
 import PostEditor from '@/components/post-editor';
+import { api } from '@/queries';
 
 export default async function Page({
   params,
@@ -14,13 +15,9 @@ export default async function Page({
     redirect('/auth/login');
   }
 
-  const { data: post, error } = await supabase
-    .from('posts')
-    .select('*')
-    .eq('id', postId)
-    .single();
+  const post = await api.posts.getById(supabase, postId);
 
-  if (error || !post) {
+  if (!post) {
     return <div className='p-6'>Post not found</div>;
   }
 

--- a/src/app/app/[org_id]/[team_id]/settings/team/page.tsx
+++ b/src/app/app/[org_id]/[team_id]/settings/team/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import UpdateTeamForm from '@/components/update-team-form'
 import { DeleteTeamButton } from '@/components/delete-team-button'
+import { api } from '@/queries'
 
 export default async function TeamSettingsPage({
   params,
@@ -18,11 +19,7 @@ export default async function TeamSettingsPage({
     redirect('/auth/login')
   }
 
-  const { data: team } = await supabase
-    .from('teams')
-    .select('*')
-    .eq('id', team_id)
-    .single()
+  const team = await api.teams.getById(supabase, team_id)
 
   return (
     <div className="min-h-screen bg-background">

--- a/src/app/app/[org_id]/members/page.tsx
+++ b/src/app/app/[org_id]/members/page.tsx
@@ -30,25 +30,18 @@ export default async function MembersPage({
     queryFn: () => api.members.getAll(supabase, org_id),
   });
 
-  const { data: orgRoles } = await supabase
-    .from('roles')
-    .select('id, name, scope')
-    .eq('org_id', org_id)
-    .eq('scope', 'organization')
+  const orgRoles = await api.roles.getByScope(
+    supabase,
+    org_id,
+    'organization',
+  )
 
-  const { data: teams } = await supabase
-    .from('teams')
-    .select('id, name')
-    .eq('org_id', org_id)
+  const teams = await api.teams.getAll(supabase, org_id)
 
   const teamRolesMap: Record<string, { id: string; name: string }[]> = {}
   if (teams && teams.length > 0) {
     const teamIds = teams.map((t) => t.id)
-    const { data: teamRoles } = await supabase
-      .from('roles')
-      .select('id, name, team_id')
-      .eq('scope', 'team')
-      .in('team_id', teamIds)
+    const teamRoles = await api.roles.getForTeams(supabase, teamIds)
 
     if (teamRoles) {
       for (const role of teamRoles) {

--- a/src/app/app/[org_id]/roles/page.tsx
+++ b/src/app/app/[org_id]/roles/page.tsx
@@ -22,10 +22,7 @@ export default async function RolesPage({
     redirect('/auth/login')
   }
 
-  const { data: teams } = await supabase
-    .from('teams')
-    .select('id, name')
-    .eq('org_id', org_id)
+  const teams = await api.teams.getAll(supabase, org_id)
   const queryClient = getQueryClient()
   await queryClient.prefetchQuery({
     // eslint-disable-next-line @tanstack/query/exhaustive-deps

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -3,6 +3,7 @@ import { createClient } from '@/lib/supabase/server'
 import { UpdateProfileForm } from '@/components/update-profile-form'
 import { ChangePasswordForm } from '@/components/change-password-form'
 import { DeleteAccountButton } from '@/components/delete-account-button'
+import { api } from '@/queries'
 
 export default async function ProfilePage() {
   const supabase = await createClient()
@@ -14,11 +15,7 @@ export default async function ProfilePage() {
     redirect('/auth/login')
   }
 
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('*')
-    .eq('id', user.id)
-    .single()
+  const profile = await api.profiles.getById(supabase, user.id)
 
   return (
     <div className="min-h-screen bg-background">

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -3,6 +3,7 @@ import { organizations } from './organizations'
 import { teams } from './teams'
 import { members } from './members'
 import { roles } from './roles'
+import { profiles } from './profiles'
 
 export const api = {
   posts,
@@ -10,6 +11,7 @@ export const api = {
   teams,
   members,
   roles,
+  profiles,
 } as const
 
 export type Api = typeof api

--- a/src/queries/profiles.ts
+++ b/src/queries/profiles.ts
@@ -1,0 +1,17 @@
+import type { Database } from '@/lib/database.types'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+async function getById(supabase: SupabaseClient<Database>, id: string) {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('id', id)
+    .single()
+  if (error) throw new Error(error.message)
+  return data
+}
+
+export const profiles = {
+  getById,
+} as const
+

--- a/src/queries/roles.ts
+++ b/src/queries/roles.ts
@@ -13,6 +13,36 @@ async function getRoles(
   return data;
 }
 
+async function getRolesByScope(
+  supabase: SupabaseClient<Database>,
+  orgId: string,
+  scope: string,
+) {
+  const { data, error } = await supabase
+    .from('roles')
+    .select('*')
+    .eq('org_id', orgId)
+    .eq('scope', scope)
+  if (error) throw new Error(error.message)
+  return data
+}
+
+async function getRolesForTeams(
+  supabase: SupabaseClient<Database>,
+  teamIds: string[],
+) {
+  if (teamIds.length === 0) return []
+  const { data, error } = await supabase
+    .from('roles')
+    .select('*')
+    .eq('scope', 'team')
+    .in('team_id', teamIds)
+  if (error) throw new Error(error.message)
+  return data
+}
+
 export const roles = {
   getAll: getRoles,
+  getByScope: getRolesByScope,
+  getForTeams: getRolesForTeams,
 } as const;


### PR DESCRIPTION
## Summary
- add profiles query helpers and export from api
- extend role queries with scoped helpers
- replace Supabase queries in pages with api calls

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68535dc47f84832fba46c12ca247e547