### PR TITLE
Restrict dynamic roles toggle to service role

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supajump",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "description": "Multi-tenant SaaS Starter Kit Monorepo",
   "scripts": {


### PR DESCRIPTION
## Summary
- remove superuser check from `set_dynamic_roles_enabled`
- limit function execution to `service_role` via GRANT/REVOKE
- bump version to 0.2.5

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68995099ac20832f9f556bd239100687