### PR TITLE
fix: use regex in slugify function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supajump",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "description": "Multi-tenant SaaS Starter Kit Monorepo",
   "scripts": {

--- a/supabase/migrations/00100_setup.sql
+++ b/supabase/migrations/00100_setup.sql
@@ -212,7 +212,7 @@ $_$;
 
 create
 or replace function public.slugify (text) returns text language sql as $_$
-    select replace(replace($1, ' ', '-'), '[^a-z0-9-]', '')
+    select regexp_replace(replace(lower($1), ' ', '-'), '[^a-z0-9-]', '', 'g')
 $_$;
 
 create

--- a/supabase/schemas/setup.sql
+++ b/supabase/schemas/setup.sql
@@ -212,7 +212,7 @@ $_$;
 
 create
 or replace function public.slugify (text) returns text language sql as $_$
-    select replace(replace($1, ' ', '-'), '[^a-z0-9-]', '')
+    select regexp_replace(replace(lower($1), ' ', '-'), '[^a-z0-9-]', '', 'g')
 $_$;
 
 create


### PR DESCRIPTION
## Summary
- use `regexp_replace` for slugify to remove non-alphanumeric characters
- bump version to 0.2.6

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6899544a949c832f99261d278eb95705